### PR TITLE
Feat/#6 lottery events 엔티티 병합합니다.

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/DrawingLottery.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/DrawingLottery.java
@@ -1,0 +1,21 @@
+package com.hyundai.softeer.backend.domain.lottery.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "drawing_lotteries")
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class DrawingLottery extends Lottery {
+    private String drawPointsJsonUrl;
+    private String contourImageUrl;
+    private String imageUrl;
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/DrawingLottery.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/DrawingLottery.java
@@ -1,21 +1,20 @@
 package com.hyundai.softeer.backend.domain.lottery.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "drawing_lotteries")
+@Table(name = "Drawing_lotteries")
 @SuperBuilder
 @Getter
 @NoArgsConstructor
 public class DrawingLottery extends Lottery {
     private String drawPointsJsonUrl;
+
     private String contourImageUrl;
+
     private String imageUrl;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/Lottery.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/Lottery.java
@@ -1,8 +1,8 @@
 package com.hyundai.softeer.backend.domain.lottery.entity;
 
-import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -13,6 +13,10 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class Lottery {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(name = "sub_event_id", nullable = false)
+    private Long subEventId;
+
+    private String winners_meta;
+
+    private String winners;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/Lottery.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/Lottery.java
@@ -1,0 +1,18 @@
+package com.hyundai.softeer.backend.domain.lottery.entity;
+
+import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@MappedSuperclass
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class Lottery {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/repository/DrawingLotteryRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/repository/DrawingLotteryRepository.java
@@ -1,0 +1,4 @@
+package com.hyundai.softeer.backend.domain.lottery.repository;
+
+public interface DrawingLotteryRepository extends LotteryRepository {
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/repository/DrawingRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/repository/DrawingRepository.java
@@ -1,0 +1,4 @@
+package com.hyundai.softeer.backend.domain.lottery.repository;
+
+public interface DrawingRepository extends LotteryRepository {
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/repository/DrawingRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/repository/DrawingRepository.java
@@ -1,4 +1,0 @@
-package com.hyundai.softeer.backend.domain.lottery.repository;
-
-public interface DrawingRepository extends LotteryRepository {
-}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/repository/LotteryRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/repository/LotteryRepository.java
@@ -1,0 +1,7 @@
+package com.hyundai.softeer.backend.domain.lottery.repository;
+
+import com.hyundai.softeer.backend.domain.lottery.entity.Lottery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LotteryRepository extends JpaRepository<Lottery, Long> {
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
@@ -1,0 +1,12 @@
+package com.hyundai.softeer.backend.domain.lottery.service;
+
+import com.hyundai.softeer.backend.domain.lottery.repository.LotteryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LotteryService {
+    private final LotteryRepository lotteryRepository;
+
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/entity/SubEvent.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/entity/SubEvent.java
@@ -1,0 +1,38 @@
+package com.hyundai.softeer.backend.domain.subevent.entity;
+
+import com.hyundai.softeer.backend.domain.lottery.entity.DrawingLottery;
+import com.hyundai.softeer.backend.domain.lottery.entity.Lottery;
+import com.hyundai.softeer.backend.domain.subevent.enums.SubEventExecuteType;
+import com.hyundai.softeer.backend.domain.subevent.enums.SubEventType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "sub_events")
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String alias;
+
+    private SubEventExecuteType executeType;
+
+    private SubEventType eventType;
+
+    private String winnersMeta;
+
+    private String winners;
+
+    private LocalDateTime startAt;
+
+    private LocalDateTime endAt;
+    
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/entity/SubEvent.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/entity/SubEvent.java
@@ -1,7 +1,5 @@
 package com.hyundai.softeer.backend.domain.subevent.entity;
 
-import com.hyundai.softeer.backend.domain.lottery.entity.DrawingLottery;
-import com.hyundai.softeer.backend.domain.lottery.entity.Lottery;
 import com.hyundai.softeer.backend.domain.subevent.enums.SubEventExecuteType;
 import com.hyundai.softeer.backend.domain.subevent.enums.SubEventType;
 import jakarta.persistence.*;
@@ -10,7 +8,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "sub_events")
+@Table(name = "Sub_events")
 @Builder
 @Getter
 @Setter
@@ -27,12 +25,8 @@ public class SubEvent {
 
     private SubEventType eventType;
 
-    private String winnersMeta;
-
-    private String winners;
-
     private LocalDateTime startAt;
 
     private LocalDateTime endAt;
-    
+
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/enums/SubEventExecuteType.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/enums/SubEventExecuteType.java
@@ -1,0 +1,23 @@
+package com.hyundai.softeer.backend.domain.subevent.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum SubEventExecuteType {
+    LOTTERY(1, "LOTTERY"),
+    FIRSTCOME(2, "FIRSTCOME");
+
+    private int code;
+    private String status;
+
+    public static SubEventExecuteType of(int code) {
+        for (SubEventExecuteType subEventExecuteType : SubEventExecuteType.values()) {
+            if (subEventExecuteType.getCode() == code) {
+                return subEventExecuteType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown code: " + code);
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/enums/SubEventType.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/enums/SubEventType.java
@@ -1,0 +1,23 @@
+package com.hyundai.softeer.backend.domain.subevent.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum SubEventType {
+    DRAWING(1, "DRAWING"),
+    QUIZ(1, "QUIZ"),;
+
+    private int code;
+    private String status;
+
+    public static SubEventType of(int code) {
+        for (SubEventType subEventHoldType : SubEventType.values()) {
+            if (subEventHoldType.getCode() == code) {
+                return subEventHoldType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown code: " + code);
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/repository/SubEventRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/repository/SubEventRepository.java
@@ -1,0 +1,7 @@
+package com.hyundai.softeer.backend.domain.subevent.repository;
+
+import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubEventRepository extends JpaRepository<SubEvent, Long> {
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/#6-lottery-events

### 💡 작업동기
- lottery events 작업을 위한 SubEvent 까지의 엔티티 생성

### 🔑 주요 변경사항
- Lottery, DrawingLottery 엔티티 생성
- SubEvent 엔티티 생성

### 관련 이슈
- closed: #6 
