### PR TITLE
이벤트 참여자들 중 N 명 추첨 메서드 구현

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
@@ -37,11 +37,11 @@ public class EventUser {
     @Builder.Default
     private Double gameScore = 0.0;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sub_event_id", nullable = false)
     private SubEvent subEvent;
 

--- a/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
@@ -1,0 +1,48 @@
+package com.hyundai.softeer.backend.domain.eventuser.entity;
+
+import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import com.hyundai.softeer.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventUser {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    private String expectationStatus;
+
+    private String lastVisitedAt;
+
+    private String sharedUrl;
+
+    @Builder.Default
+    private Double sharedScore = 0.0;
+
+    @Builder.Default
+    private Double priorityScore = 0.0;
+
+    @Builder.Default
+    private Double lottoScore = 0.0;
+
+    @Builder.Default
+    private Double gameScore = 0.0;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "sub_event_id", nullable = false)
+    private SubEvent subEvent;
+
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/eventuser/repository/EventUserRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/eventuser/repository/EventUserRepository.java
@@ -1,0 +1,7 @@
+package com.hyundai.softeer.backend.domain.eventuser.repository;
+
+import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventUserRepository extends JpaRepository<EventUser, Long> {
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/DrawingLotteryEvent.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/DrawingLotteryEvent.java
@@ -1,0 +1,18 @@
+package com.hyundai.softeer.backend.domain.lottery.entity;
+
+import com.hyundai.softeer.backend.domain.subevent.entity.BaseSubEvent;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class DrawingLotteryEvent extends BaseSubEvent {
+    
+
+    private String drawPointsJsonUrl;
+
+    private String contourImageUrl;
+
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
@@ -1,0 +1,35 @@
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class LotteryService {
+
+    /**
+     * 당첨자 선정 메서드
+     *
+     * @param winnersMeta 당첨자 메타 데이터
+     * @param eventUsers  1차 랜덤 선정된 참여자 리스트
+     * @param scoreWeight 각 스코어에 대한 가중치
+     * @return 당첨자 리스트
+     */
+    public List<WinnerCandidate> getWinners(Map<Integer, WinnerInfo> winnersMeta, List<EventUser> eventUsers, LotteryScoreWeight scoreWeight) {
+        int totalWinners = winnersMeta.values().stream()
+                .mapToInt(WinnerInfo::getWinnerCount)
+                .sum();
+
+        List<WinnerCandidate> candidates = new java.util.ArrayList<>(eventUsers.stream()
+                .map(eventUser -> {
+                    double eventRandomScore = Math.random();
+                    eventRandomScore += calculateWeightedValue(eventUser, scoreWeight);
+                    return new WinnerCandidate(eventUser.getId(), eventRandomScore);
+                })
+                .toList());
+
+        // 당첨자들을 난수에 따라 정렬
+        candidates.sort(Comparator.comparingDouble(WinnerCandidate::getRandomValue).reversed());
+
+        // 최종 당첨자 리스트 (예: 상위 N 명)
+        return candidates.stream()
+                .limit(totalWinners)
+                .toList();
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
@@ -63,7 +63,7 @@ public class LotteryService {
                 (gameScore * scoreWeight.getGameWeight());
     }
 
-    public static Map<Integer, WinnerInfo> parseWinnersMeta(String winnersMeta) {
+    private Map<Integer, WinnerInfo> parseWinnersMeta(String winnersMeta) {
         Map<Integer, WinnerInfo> resultMap = new HashMap<>();
         ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
@@ -32,4 +32,30 @@ public class LotteryService {
                 .limit(totalWinners)
                 .toList();
     }
+    public static Map<Integer, WinnerInfo> parseWinnersMeta(String winnersMeta) {
+        Map<Integer, WinnerInfo> resultMap = new HashMap<>();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            // JSON 문자열을 JsonNode로 변환
+            JsonNode rootNode = objectMapper.readTree(winnersMeta.replace("'", "\""));
+
+            // 각 키와 값 파싱
+            rootNode.fields().forEachRemaining(entry -> {
+                Integer rank = Integer.valueOf(entry.getKey());
+                JsonNode values = entry.getValue();
+
+                int winnerCount = values.get(0).asInt();
+                int prizeId = values.get(1).asInt();
+
+                resultMap.put(rank, new WinnerInfo(winnerCount, prizeId));
+            });
+
+        } catch (IOException e) {
+            // TODO 예외 처리
+            e.printStackTrace();
+        }
+        return resultMap;
+    }
+
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryService.java
@@ -1,3 +1,21 @@
+package com.hyundai.softeer.backend.domain.lottery.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
+import com.hyundai.softeer.backend.domain.subevent.dto.LotteryScoreWeight;
+import com.hyundai.softeer.backend.domain.subevent.dto.WinnerCandidate;
+import com.hyundai.softeer.backend.domain.subevent.dto.WinnerInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -32,6 +50,19 @@ public class LotteryService {
                 .limit(totalWinners)
                 .toList();
     }
+
+    private double calculateWeightedValue(EventUser eventUser, LotteryScoreWeight scoreWeight) {
+        double sharedScore = eventUser.getSharedScore();
+        double priorityScore = eventUser.getPriorityScore();
+        double lottoScore = eventUser.getLottoScore();
+        double gameScore = eventUser.getGameScore();
+
+        return (sharedScore * scoreWeight.getSharedWeight()) +
+                (priorityScore * scoreWeight.getPriorityWeight()) +
+                (lottoScore * scoreWeight.getLottoWeight()) +
+                (gameScore * scoreWeight.getGameWeight());
+    }
+
     public static Map<Integer, WinnerInfo> parseWinnersMeta(String winnersMeta) {
         Map<Integer, WinnerInfo> resultMap = new HashMap<>();
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/dto/LotteryScoreWeight.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/dto/LotteryScoreWeight.java
@@ -1,0 +1,13 @@
+package com.hyundai.softeer.backend.domain.subevent.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LotteryScoreWeight {
+    private double sharedWeight;
+    private double priorityWeight;
+    private double lottoWeight;
+    private double gameWeight;
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/dto/WinnerCandidate.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/dto/WinnerCandidate.java
@@ -1,0 +1,19 @@
+package com.hyundai.softeer.backend.domain.subevent.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WinnerCandidate {
+    private Long eventUserId;
+    private double randomValue;
+
+    @Override
+    public String toString() {
+        return "WinnerCandidate{" +
+                "eventUserId=" + eventUserId +
+                ", randomValue=" + randomValue +
+                '}';
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/dto/WinnerInfo.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/dto/WinnerInfo.java
@@ -1,0 +1,11 @@
+package com.hyundai.softeer.backend.domain.subevent.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WinnerInfo {
+    private int winnerCount;
+    private int prizeId;
+}

--- a/src/test/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryServiceTest.java
+++ b/src/test/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryServiceTest.java
@@ -19,26 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MockitoExtension.class)
 @Slf4j
 class LotteryServiceTest {
-    private static final Logger log = LoggerFactory.getLogger(LotteryServiceTest.class);
     @InjectMocks
     private LotteryService lotteryService;
-
-    @Test
-    @DisplayName("당첨자 메타 데이터 파싱")
-    void parseWinnerMeta() {
-        // given
-        String winnerMeta = "{'1':[1,1],'2':[2,2],'3':[3,3],'4':[4,4],'5':[5,5],'6':[6,6],'7':[7,7],'8':[8,8],'9':[9,9],'10':[10,10]}";
-        // when
-        Map<Integer, WinnerInfo> integerWinnerInfoMap = lotteryService.parseWinnersMeta(winnerMeta);
-
-        // then
-        for (int i = 1; i <= 10; i++) {
-            WinnerInfo winnerInfo = integerWinnerInfoMap.get(i);
-            assertThat(winnerInfo).isNotNull();
-            assertThat(winnerInfo.getWinnerCount()).isEqualTo(i);
-            assertThat(winnerInfo.getPrizeId()).isEqualTo(i);
-        }
-    }
 
     @Test
     @DisplayName("당첨자 선정")

--- a/src/test/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryServiceTest.java
+++ b/src/test/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryServiceTest.java
@@ -4,13 +4,12 @@ import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
 import com.hyundai.softeer.backend.domain.subevent.dto.LotteryScoreWeight;
 import com.hyundai.softeer.backend.domain.subevent.dto.WinnerCandidate;
 import com.hyundai.softeer.backend.domain.subevent.dto.WinnerInfo;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -18,6 +17,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
+@Slf4j
 class LotteryServiceTest {
     private static final Logger log = LoggerFactory.getLogger(LotteryServiceTest.class);
     @InjectMocks

--- a/src/test/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryServiceTest.java
+++ b/src/test/java/com/hyundai/softeer/backend/domain/lottery/service/LotteryServiceTest.java
@@ -1,0 +1,66 @@
+package com.hyundai.softeer.backend.domain.lottery.service;
+
+import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
+import com.hyundai.softeer.backend.domain.subevent.dto.LotteryScoreWeight;
+import com.hyundai.softeer.backend.domain.subevent.dto.WinnerCandidate;
+import com.hyundai.softeer.backend.domain.subevent.dto.WinnerInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class LotteryServiceTest {
+    private static final Logger log = LoggerFactory.getLogger(LotteryServiceTest.class);
+    @InjectMocks
+    private LotteryService lotteryService;
+
+    @Test
+    @DisplayName("당첨자 메타 데이터 파싱")
+    void parseWinnerMeta() {
+        // given
+        String winnerMeta = "{'1':[1,1],'2':[2,2],'3':[3,3],'4':[4,4],'5':[5,5],'6':[6,6],'7':[7,7],'8':[8,8],'9':[9,9],'10':[10,10]}";
+        // when
+        Map<Integer, WinnerInfo> integerWinnerInfoMap = lotteryService.parseWinnersMeta(winnerMeta);
+
+        // then
+        for (int i = 1; i <= 10; i++) {
+            WinnerInfo winnerInfo = integerWinnerInfoMap.get(i);
+            assertThat(winnerInfo).isNotNull();
+            assertThat(winnerInfo.getWinnerCount()).isEqualTo(i);
+            assertThat(winnerInfo.getPrizeId()).isEqualTo(i);
+        }
+    }
+
+    @Test
+    @DisplayName("당첨자 선정")
+    void getWinners() {
+        // given
+        List<EventUser> users = List.of(
+                EventUser.builder().id(1L).build(),
+                EventUser.builder().id(2L).build(),
+                EventUser.builder().id(3L).build(),
+                EventUser.builder().id(4L).build(),
+                EventUser.builder().id(5L).build());
+
+        Map<Integer, WinnerInfo> winnersMeta = Map.of(
+                1, new WinnerInfo(3, 1));
+        LotteryScoreWeight scoreWeight = new LotteryScoreWeight(1.0, 1.0, 1.0, 1.0);
+
+        // when
+
+        List<WinnerCandidate> winners = lotteryService.getWinners(winnersMeta, users, scoreWeight);
+        log.info("당첨자: {}", winners);
+
+        // then
+        assertThat(winners).hasSize(3);
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #14 

### 💡 작업동기
- 추첨 이벤트에서 당첨자 추첨을 위한 기본 작업

### 🔑 주요 변경사항
- 기본 엔티티 생성 및 주어진 가중치, 메타 데이터, 유저 리스트에서 N 명 뽑아내는 메서드 생성

### 🏞 스크린샷
<img width="1377" alt="image" src="https://github.com/user-attachments/assets/91ef6f8f-6ef3-49d1-aaf1-0f3a58b8ecca">

### 관련 이슈
- #14 