### PR TITLE
드로잉 추첨 랜딩 페이지 API 구현

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/eventuser/dto/EventUserInfoDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/eventuser/dto/EventUserInfoDto.java
@@ -1,0 +1,53 @@
+package com.hyundai.softeer.backend.domain.eventuser.dto;
+
+import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class EventUserInfoDto {
+    @Schema(description = "마지막 방문 시간", example = "2021-08-01T00:00:00")
+    private LocalDateTime lastVisitedAt;
+
+    @Schema(description = "공유 URL", example = "https://www.hyundai.com")
+    private String sharedUrl;
+
+    @Schema(description = "공유 점수", example = "3.0")
+    private Double sharedScore;
+
+    @Schema(description = "우선순위 점수", example = "10.0")
+    private Double priorityScore;
+
+    @Schema(description = "추첨 점수", example = "3.2")
+    private Double lottoScore;
+
+    @Schema(description = "게임 점수", example = "99.3")
+    private Double gameScore;
+
+    @Schema(description = "참여 기회", example = "1")
+    private Integer chance;
+
+    @Schema(description = "기대평 보너스 참여 기회", example = "1")
+    private Integer expectationBonusChance;
+
+    @Schema(description = "공유 보너스 참여 기회", example = "-1")
+    private Integer shareBonusChance;
+
+    public static EventUserInfoDto fromEntity(EventUser eventUser) {
+        return EventUserInfoDto.builder()
+                .lastVisitedAt(eventUser.getLastVisitedAt())
+                .sharedUrl(eventUser.getSharedUrl())
+                .sharedScore(eventUser.getSharedScore())
+                .priorityScore(eventUser.getPriorityScore())
+                .lottoScore(eventUser.getLottoScore())
+                .gameScore(eventUser.getGameScore())
+                .chance(eventUser.getChance())
+                .expectationBonusChance(eventUser.getExpectationBonusChance())
+                .shareBonusChance(eventUser.getShareBonusChance())
+                .build();
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -19,9 +21,9 @@ public class EventUser {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    private String expectationStatus;
+    private Boolean isWriteExpectation;
 
-    private String lastVisitedAt;
+    private LocalDateTime lastVisitedAt;
 
     private String sharedUrl;
 
@@ -36,6 +38,14 @@ public class EventUser {
 
     @Builder.Default
     private Double gameScore = 0.0;
+
+    private Integer chance;
+
+    @Builder.Default
+    private Integer expectationBonusChance = -1;
+
+    @Builder.Default
+    private Integer shareBonusChance = -1;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/hyundai/softeer/backend/domain/eventuser/repository/EventUserRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/eventuser/repository/EventUserRepository.java
@@ -4,4 +4,5 @@ import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventUserRepository extends JpaRepository<EventUser, Long> {
+    EventUser findByUserIdAndSubEventId(Long userId, Long subEventId);
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/service/QuizService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/service/QuizService.java
@@ -64,8 +64,8 @@ public class QuizService {
                 .orElseThrow(() -> new QuizNotFoundException());
 
         return QuizLandResponseDto.builder()
-                .bannerImg(subEvent.getBannerUrl())
-                .eventImg(subEvent.getEventImgUrl())
+                .bannerImg(subEvent.getBannerImgUrl())
+                .eventImg(subEvent.getEventImgUrls())
                 .startTime(subEvent.getStartAt())
                 .endTime(subEvent.getEndAt())
                 .serverTime(LocalDateTime.now())

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/DrawingLotteryController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/DrawingLotteryController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class DrawingLotteryController {
     private final DrawingLotteryService drawingLotteryService;
 
-
+    @GetMapping("/land")
     @Operation(summary = "드로잉 추첨 이벤트 랜딩 페이지 조회", description = """
             # 드로잉 추첨 이벤트 랜딩 페이지 조회
                         
@@ -46,7 +47,7 @@ public class DrawingLotteryController {
             @ApiResponse(responseCode = "200", description = "드로잉 추첨 이벤트 랜딩 페이지 조회 성공", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = DrawingLotteryLandResponseDto.class))}),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 이벤트 정보", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = BaseResponse.class), examples = @ExampleObject("{\"message\":\"드로잉 이벤트가 존재하지 않습니다.\",\"status\":404}"))}),
     })
-    @GetMapping("/land")
+    @SecurityRequirement(name = "access-token")
     public DrawingLotteryLandResponseDto getQuizLandingPage(
             @Parameter(hidden = true) @CurrentUser User user,
             @RequestParam("eventId") Long eventId

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/DrawingLotteryController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/DrawingLotteryController.java
@@ -1,0 +1,57 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.controller;
+
+import com.hyundai.softeer.backend.domain.lottery.drawing.dto.DrawingLotteryLandResponseDto;
+import com.hyundai.softeer.backend.domain.lottery.drawing.service.DrawingLotteryService;
+import com.hyundai.softeer.backend.domain.user.entity.User;
+import com.hyundai.softeer.backend.global.dto.BaseResponse;
+import com.hyundai.softeer.backend.global.jwt.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1/lottery/drawing")
+@Tag(name = "Drawing Lottery")
+public class DrawingLotteryController {
+    private final DrawingLotteryService drawingLotteryService;
+
+
+    @Operation(summary = "드로잉 추첨 이벤트 랜딩 페이지 조회", description = """
+            # 드로잉 추첨 이벤트 랜딩 페이지 조회
+                        
+            - 드로잉 추첨 이벤트 랜딩 페이지의 기본 정보를 조회합니다.
+            - 로그인 된 유저의 해당 이벤트 참여 정보를 함께 반환합니다.
+             
+            ## 응답
+                        
+            - 조회 성공 시 `200` 코드와 랜딩 페이지 정보를 반환합니다.
+            - 이벤트 번호에 오류가 있을 경우 `404` 에러를 반환합니다.
+             
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "드로잉 추첨 이벤트 랜딩 페이지 조회 성공", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = DrawingLotteryLandResponseDto.class))}),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 이벤트 정보", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = BaseResponse.class), examples = @ExampleObject("{\"message\":\"드로잉 이벤트가 존재하지 않습니다.\",\"status\":404}"))}),
+    })
+    @GetMapping("/land")
+    public DrawingLotteryLandResponseDto getQuizLandingPage(
+            @Parameter(hidden = true) @CurrentUser User user,
+            @RequestParam("eventId") Long eventId
+    ) {
+
+        return drawingLotteryService.getDrawingLotteryLand(user, eventId);
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/dto/DrawingLotteryLandDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/dto/DrawingLotteryLandDto.java
@@ -1,0 +1,34 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.dto;
+
+import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DrawingLotteryLandDto {
+    @Schema(description = "배너 이미지 url", example = "https://www.example.com/banner.jpg")
+    private String bannerImgUrl;
+
+    //TODO : 파싱을 해서 주어야하는 지, 확인
+    @Schema(description = "이벤트 이미지 url", example = "{ \"description_url\": \"https://www.example.com/description.jpg\", \"main_url\": \"https://www.example.com/main.jpg\" }")
+    private String eventImgUrls;
+
+    @Schema(description = "이벤트 시작 시간", example = "2021-08-01T00:00:00")
+    private LocalDateTime startAt;
+
+    @Schema(description = "이벤트 종료 시간", example = "2021-08-30T00:00:00")
+    private LocalDateTime endAt;
+
+    public static DrawingLotteryLandDto fromEntity(SubEvent subEvent) {
+        return DrawingLotteryLandDto.builder()
+                .bannerImgUrl(subEvent.getBannerImgUrl())
+                .eventImgUrls(subEvent.getEventImgUrls())
+                .startAt(subEvent.getStartAt())
+                .endAt(subEvent.getEndAt())
+                .build();
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/dto/DrawingLotteryLandResponseDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/dto/DrawingLotteryLandResponseDto.java
@@ -1,0 +1,12 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.dto;
+
+import com.hyundai.softeer.backend.domain.eventuser.dto.EventUserInfoDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DrawingLotteryLandResponseDto {
+    private EventUserInfoDto userInfo;
+    private DrawingLotteryLandDto eventInfo;
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/entity/DrawingLottery.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/entity/DrawingLottery.java
@@ -1,4 +1,4 @@
-package com.hyundai.softeer.backend.domain.lottery.entity;
+package com.hyundai.softeer.backend.domain.lottery.drawing.entity;
 
 import com.hyundai.softeer.backend.domain.subevent.entity.BaseSubEvent;
 import lombok.Getter;
@@ -8,11 +8,11 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Getter
 @NoArgsConstructor
-public class DrawingLotteryEvent extends BaseSubEvent {
-    
-
+public class DrawingLottery extends BaseSubEvent {
     private String drawPointsJsonUrl;
 
-    private String contourImageUrl;
+    private String contourImgUrl;
+
+    private String imgUrl;
 
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/exception/DrawingNotFoundException.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/exception/DrawingNotFoundException.java
@@ -1,0 +1,10 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.exception;
+
+import com.hyundai.softeer.backend.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class DrawingNotFoundException extends BaseException {
+    public DrawingNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "드로잉 이벤트가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/service/DrawingLotteryService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/service/DrawingLotteryService.java
@@ -1,0 +1,53 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.service;
+
+import com.hyundai.softeer.backend.domain.eventuser.dto.EventUserInfoDto;
+import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
+import com.hyundai.softeer.backend.domain.eventuser.repository.EventUserRepository;
+import com.hyundai.softeer.backend.domain.lottery.drawing.dto.DrawingLotteryLandDto;
+import com.hyundai.softeer.backend.domain.lottery.drawing.dto.DrawingLotteryLandResponseDto;
+import com.hyundai.softeer.backend.domain.lottery.drawing.exception.DrawingNotFoundException;
+import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import com.hyundai.softeer.backend.domain.subevent.enums.SubEventType;
+import com.hyundai.softeer.backend.domain.subevent.repository.SubEventRepository;
+import com.hyundai.softeer.backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DrawingLotteryService {
+    private final SubEventRepository subEventRepository;
+    private final EventUserRepository eventUserRepository;
+
+    @Transactional(readOnly = true)
+    public DrawingLotteryLandResponseDto getDrawingLotteryLand(User user, Long eventId) {
+        List<SubEvent> events = subEventRepository.findByEventId(eventId);
+        SubEvent drawing = findDrawingEvent(events);
+
+        if (drawing == null) {
+            throw new DrawingNotFoundException();
+        }
+
+        EventUser eventUser = eventUserRepository.findByUserIdAndSubEventId(user.getId(), drawing.getId());
+
+        return DrawingLotteryLandResponseDto.builder()
+                .userInfo(EventUserInfoDto.fromEntity(eventUser))
+                .eventInfo(DrawingLotteryLandDto.fromEntity(drawing))
+                .build();
+    }
+
+    private SubEvent findDrawingEvent(List<SubEvent> subEvents) {
+        for (SubEvent subEvent : subEvents) {
+            if (subEvent.getEventType().equals(SubEventType.DRAWING)) {
+                return subEvent;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/entity/SubEvent.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/entity/SubEvent.java
@@ -6,8 +6,6 @@ import com.hyundai.softeer.backend.domain.subevent.enums.SubEventType;
 import com.hyundai.softeer.backend.global.dto.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
@@ -37,7 +35,9 @@ public class SubEvent extends BaseEntity {
 
     private LocalDateTime endAt;
 
-    private String bannerUrl;
+    private String bannerImgUrl;
 
-    private String eventImgUrl;
+    private String eventImgUrls;
+
+
 }

--- a/src/main/java/com/hyundai/softeer/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/hyundai/softeer/backend/global/config/SwaggerConfig.java
@@ -41,7 +41,8 @@ public class SwaggerConfig {
 
     private List<Tag> tagList() {
         return List.of(
-                new Tag().name("User").description("사용자 관련 API")
+                new Tag().name("User").description("사용자 관련 API"),
+                new Tag().name("Drawing Lottery").description("드로잉 추첨 이벤트 관련 API")
         );
     }
 }

--- a/src/test/java/com/hyundai/softeer/backend/domain/lottery/drawing/service/DrawingLotteryServiceTest.java
+++ b/src/test/java/com/hyundai/softeer/backend/domain/lottery/drawing/service/DrawingLotteryServiceTest.java
@@ -1,0 +1,76 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.service;
+
+import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
+import com.hyundai.softeer.backend.domain.eventuser.repository.EventUserRepository;
+import com.hyundai.softeer.backend.domain.lottery.drawing.exception.DrawingNotFoundException;
+import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import com.hyundai.softeer.backend.domain.subevent.enums.SubEventType;
+import com.hyundai.softeer.backend.domain.subevent.repository.SubEventRepository;
+import com.hyundai.softeer.backend.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+class DrawingLotteryServiceTest {
+
+    @InjectMocks
+    private DrawingLotteryService drawingLotteryService;
+
+    @Mock
+    private SubEventRepository subEventRepository;
+
+    @Mock
+    private EventUserRepository eventUserRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("드로잉 추첨 이벤트 랜딩 페이지 조회 성공")
+    void getDrawingLotteryLand() {
+        // Given
+        User user = new User();
+        Long eventId = 1L;
+        SubEvent drawingEvent = new SubEvent();
+        drawingEvent.setEventType(SubEventType.DRAWING);
+        EventUser eventUser = new EventUser();
+
+        List<SubEvent> events = Arrays.asList(drawingEvent);
+
+        // When
+        when(subEventRepository.findByEventId(eventId)).thenReturn(events);
+        when(eventUserRepository.findByUserIdAndSubEventId(user.getId(), drawingEvent.getId())).thenReturn(eventUser);
+
+        // Then
+        assertDoesNotThrow(() -> drawingLotteryService.getDrawingLotteryLand(user, eventId));
+    }
+
+    @Test
+    @DisplayName("드로잉 추첨 이벤트 랜딩 페이지 조회 실패")
+    void getDrawingLotteryLand_noDrawingEvent() {
+        // Given
+        User user = new User();
+        Long eventId = 1L;
+        SubEvent nonDrawingEvent = new SubEvent();
+        nonDrawingEvent.setEventType(SubEventType.QUIZ);
+        List<SubEvent> events = Arrays.asList(nonDrawingEvent);
+
+        // When
+        when(subEventRepository.findByEventId(eventId)).thenReturn(events);
+
+        // Then
+        assertThrows(DrawingNotFoundException.class, () -> drawingLotteryService.getDrawingLotteryLand(user, eventId));
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #38 

### 💡 작업동기
- 드로잉 이벤트 랜딩 페이지를 위한 데이터 반환

### 🔑 주요 변경사항
- 드로잉 이벤트 서비스 구현
- event Id 를 입력받아 UserInfo, EventInfo 를 담아 반환

### 🏞 스크린샷
<img width="1116" alt="image" src="https://github.com/user-attachments/assets/bb2a7eb7-a6c6-4c0c-9494-2a8ca1881d61">

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/53ad8fe4-8c71-4f01-91b8-f3c2c38846e6">


### 관련 이슈
- #38 
