### PR TITLE
BaseSubEvent 엔티티 LotteryEvent, FirstComeEvent 로 분리합니다.

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/entity/FirstComeEvent.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/entity/FirstComeEvent.java
@@ -1,4 +1,4 @@
-package com.hyundai.softeer.backend.domain.subevent.entity;
+package com.hyundai.softeer.backend.domain.firstcomeevent.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Id;
@@ -13,11 +13,10 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @Setter
 @NoArgsConstructor
-public class BaseSubEvent {
+public class FirstComeEvent {
     @Id
     @Column(name = "sub_event_id", nullable = false)
     private Long subEventId;
-
-
+    
     private Integer winners;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/controller/QuizController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/controller/QuizController.java
@@ -1,12 +1,11 @@
 package com.hyundai.softeer.backend.domain.firstcomeevent.quiz.controller;
 
+import com.hyundai.softeer.backend.domain.firstcomeevent.quiz.dto.QuizLandResponseDto;
 import com.hyundai.softeer.backend.domain.firstcomeevent.quiz.dto.QuizResponseDto;
 import com.hyundai.softeer.backend.domain.firstcomeevent.quiz.dto.QuizSubmitRequest;
 import com.hyundai.softeer.backend.domain.firstcomeevent.quiz.dto.QuizSubmitResponseDto;
 import com.hyundai.softeer.backend.domain.firstcomeevent.quiz.service.QuizService;
-import com.hyundai.softeer.backend.domain.firstcomeevent.quiz.dto.QuizLandResponseDto;
 import com.hyundai.softeer.backend.domain.user.entity.User;
-import com.hyundai.softeer.backend.global.dto.BaseEntity;
 import com.hyundai.softeer.backend.global.dto.BaseResponse;
 import com.hyundai.softeer.backend.global.exception.ApiErrorResponse;
 import com.hyundai.softeer.backend.global.jwt.CurrentUser;
@@ -18,9 +17,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -31,17 +27,17 @@ public class QuizController {
     private final QuizService quizService;
 
     @Operation(summary = "퀴즈 문제 페이지 정보", description = """
-    # 퀴즈 문제를 반환해주는 api
-    
-    - i번 퀴즈에 대한 정보를 응답합니다.
-    - 로그인 되어 있지 않아도 접근 가능합니다.
-    
-    ## 응답
-    
-    - 쿼리 파라미터의 타입이 잘못되었거나 존재하지 않으면 예외가 발생할 수 있습니다.
-    - 현재 진행할 예정이거나 진행중인 퀴즈가 없으면 예외가 발생할 수 있습니다.
+            # 퀴즈 문제를 반환해주는 api
+                
+            - i번 퀴즈에 대한 정보를 응답합니다.
+            - 로그인 되어 있지 않아도 접근 가능합니다.
+                
+            ## 응답
+                
+            - 쿼리 파라미터의 타입이 잘못되었거나 존재하지 않으면 예외가 발생할 수 있습니다.
+            - 현재 진행할 예정이거나 진행중인 퀴즈가 없으면 예외가 발생할 수 있습니다.
 
-    """)
+            """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "정상 반환 시", useReturnTypeSchema = true),
             @ApiResponse(responseCode = "400", description = "쿼리 파라미터의 타입이 잘못되었거나 존재하지 않을 때"),
@@ -51,7 +47,7 @@ public class QuizController {
     public BaseResponse<QuizResponseDto> getQuiz(
             @RequestParam("eventId") Long eventId,
             @RequestParam("problemNumber") Integer problemNumber
-            ) {
+    ) {
         QuizResponseDto quizResponse = quizService.getQuiz(eventId, problemNumber);
 
         return BaseResponse.<QuizResponseDto>builder()
@@ -60,18 +56,18 @@ public class QuizController {
     }
 
     @Operation(summary = "퀴즈 랜딩 페이지 정보", description = """
-    # 퀴즈 랜딩 페이지 정보를 반환해주는 api
-    
-    - 현재 이벤트에서 가장 가까운 퀴즈 문제를 반환합니다.
-        - 퀴즈 이벤트 시작 전 (남은 시간이 존재합니다.)
-        - 퀴즈 이벤트 중 (남은 시간 0을 반환합니다.)
-    
-    ## 응답
-    
-    - 쿼리 파라미터의 타입이 지켜지지 않거나 존재하지 않으면 예외가 발생합니다.
-    - 현재 이벤트가 존재하지 않거나 퀴즈 문제가 존재하지 않으면 예외가 발생합니다.
-    
-    """)
+            # 퀴즈 랜딩 페이지 정보를 반환해주는 api
+                
+            - 현재 이벤트에서 가장 가까운 퀴즈 문제를 반환합니다.
+                - 퀴즈 이벤트 시작 전 (남은 시간이 존재합니다.)
+                - 퀴즈 이벤트 중 (남은 시간 0을 반환합니다.)
+                
+            ## 응답
+                
+            - 쿼리 파라미터의 타입이 지켜지지 않거나 존재하지 않으면 예외가 발생합니다.
+            - 현재 이벤트가 존재하지 않거나 퀴즈 문제가 존재하지 않으면 예외가 발생합니다.
+                
+            """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "정상 반환 시", useReturnTypeSchema = true),
             @ApiResponse(responseCode = "400", description = "GET 요청의 query parameter가 숫자가 아니거나 존재하지 않을 때", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class))}),
@@ -90,17 +86,17 @@ public class QuizController {
 
 
     @Operation(summary = "퀴즈 제출을 채점하는 api", description = """
-    # 퀴즈 제출을 체점하는 api
-    
-    - 퀴즈의 답변을 보내면 그에 맞는 응답을 보냅니다.
-    
-    ## 응답
-    1. 정답이 틀린 경우
-    2. 정답은 맞았으나 선착순에 들지 못한 경우.
-    3. 정답도 맞고 선착순에도 든 경우.
-    
-    - request body의 객체의 타입이 맞지 않거나 없는 경우 예외가 발생합니다.
-    """)
+            # 퀴즈 제출을 체점하는 api
+                
+            - 퀴즈의 답변을 보내면 그에 맞는 응답을 보냅니다.
+                
+            ## 응답
+            1. 정답이 틀린 경우
+            2. 정답은 맞았으나 선착순에 들지 못한 경우.
+            3. 정답도 맞고 선착순에도 든 경우.
+                
+            - request body의 객체의 타입이 맞지 않거나 없는 경우 예외가 발생합니다.
+            """)
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/entity/Quiz.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/entity/Quiz.java
@@ -1,43 +1,45 @@
 package com.hyundai.softeer.backend.domain.firstcomeevent.quiz.entity;
 
+import com.hyundai.softeer.backend.domain.firstcomeevent.entity.FirstComeEvent;
 import com.hyundai.softeer.backend.domain.prize.entity.Prize;
-import com.hyundai.softeer.backend.domain.subevent.entity.BaseSubEvent;
-import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name="Quizzes")
+@Table(name = "Quizzes")
 @SuperBuilder
 @NoArgsConstructor
 @Getter
 @Setter
-public class Quiz extends BaseSubEvent {
+public class Quiz extends FirstComeEvent {
 
-  private Integer sequence;
+    private Integer sequence;
 
-  private String overview;
+    private String overview;
 
-  private String problem;
+    private String problem;
 
-  private String carInfo;
+    private String carInfo;
 
-  private String answer;
+    private String answer;
 
-  private String hint;
-  /**
-   * 추후 결정
-   */
-  private String anchor;
+    private String hint;
+    /**
+     * 추후 결정
+     */
+    private String anchor;
 
-  private String initConsonant;
+    private String initConsonant;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  private Prize prize;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Prize prize;
 
-  private Integer winnerCount;
+    private Integer winnerCount;
 
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/entity/DrawingLotteryEvent.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/entity/DrawingLotteryEvent.java
@@ -1,6 +1,6 @@
 package com.hyundai.softeer.backend.domain.lottery.drawing.entity;
 
-import com.hyundai.softeer.backend.domain.subevent.entity.BaseSubEvent;
+import com.hyundai.softeer.backend.domain.lottery.entity.LotteryEvent;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -8,12 +8,10 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Getter
 @NoArgsConstructor
-public class DrawingLotteryEvent extends BaseSubEvent {
+public class DrawingLotteryEvent extends LotteryEvent {
     private String drawPointsJsonUrl;
 
     private String contourImgUrl;
 
     private String imgUrl;
-
-    private String winners_meta;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/LotteryEvent.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/entity/LotteryEvent.java
@@ -1,0 +1,22 @@
+package com.hyundai.softeer.backend.domain.lottery.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@MappedSuperclass
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+public class LotteryEvent {
+    @Id
+    @Column(name = "sub_event_id", nullable = false)
+    private Long subEventId;
+
+    private String winners_meta;
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #63

### 💡 작업동기
- 추첨과 선착순 이벤트에 대한 기본 명세가 달라 BaseSubEvent 엔티티 분리

### 🔑 주요 변경사항
- BaseSubEvent 엔티티를 Lottery 와 FirstCome 으로 변경

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- #63 
