### PR TITLE
hotfix: json이 문자열 그대로 문제 해결

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/event/exception/EventNotWithinPeriodException.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/event/exception/EventNotWithinPeriodException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class EventNotWithinPeriodException extends BaseException {
     public EventNotWithinPeriodException() {
-        super(HttpStatus.ACCEPTED, "이벤트 기간이 아닙니다.");
+        super(HttpStatus.NOT_FOUND, "이벤트 기간이 아닙니다.");
     }
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/dto/QuizLandResponseDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/dto/QuizLandResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Builder
 @Getter
@@ -19,7 +20,7 @@ public class QuizLandResponseDto {
     private String bannerImg;
 
     @Schema(description = "이벤트 이미지 Url", example = "https://www.awss3/eventImg")
-    private String eventImg;
+    private Map<String, Object> eventImg;
 
     @Schema(description = "이벤트까지 남은 시간", example = "3959")
     private Long remainSecond;

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/dto/DrawingLotteryLandDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/dto/DrawingLotteryLandDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Getter
 @Builder
@@ -15,7 +16,7 @@ public class DrawingLotteryLandDto {
 
     //TODO : 파싱을 해서 주어야하는 지, 확인
     @Schema(description = "이벤트 이미지 url", example = "{ \"description_url\": \"https://www.example.com/description.jpg\", \"main_url\": \"https://www.example.com/main.jpg\" }")
-    private String eventImgUrls;
+    private Map<String, Object> eventImgUrls;
 
     @Schema(description = "이벤트 시작 시간", example = "2021-08-01T00:00:00")
     private LocalDateTime startAt;

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/entity/SubEvent.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/entity/SubEvent.java
@@ -6,8 +6,12 @@ import com.hyundai.softeer.backend.domain.subevent.enums.SubEventType;
 import com.hyundai.softeer.backend.global.dto.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
 @Table(name = "Sub_events")
@@ -37,7 +41,7 @@ public class SubEvent extends BaseEntity {
 
     private String bannerImgUrl;
 
-    private String eventImgUrls;
-
-
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> eventImgUrls;
 }

--- a/src/main/resources/sql/integration.sql
+++ b/src/main/resources/sql/integration.sql
@@ -12,12 +12,12 @@ INSERT INTO cars (id, brand_name, car_name_eng, car_name_kor, model_line, price,
 values (1, 0, "santafe", "산타페", 0, 30000000, "2024-07-01 10:00:00");
 
 INSERT INTO events (id, end_at, event_name, event_registered_at, event_status, start_at, winner_count, car_id)
-values (1, "2024-07-01 10:00:00", "별 헤는 밤", "2024-06-28 00:00:00", 0, "2024-06-25 10:00:00", 10, 1);
+values (1, "2024-09-01 10:00:00", "별 헤는 밤", "2024-06-28 00:00:00", 0, "2024-08-01 10:00:00", 10, 1);
 
 INSERT INTO sub_events (id, event_id, alias, execute_type, event_type, start_at, end_at, banner_img_url, event_img_urls)
-values (1, 1, "퀴즈 테스트", 1, 1, "2024-06-25 10:30:00", "2024-06-26 10:30:00", "www.banner1.com", "www.event1.com"),
-       (2, 1, "ㅣ히히", 1, 1, "2024-06-27 10:30:00", "2024-06-28 10:30:00", "www.banner2.com", "www.event2.com"),
-       (3, 1, "퀴즈 시러", 1, 1, "2024-06-29 10:30:00", "2024-06-30 10:30:00", "www.banner3.com", "www.event3.com");
+values (1, 1, "퀴즈 테스트", 1, 1, "2024-08-06 10:30:00", "2024-08-08 10:30:00", "www.banner1.com", json_object('main', 'www.event1.com')),
+       (2, 1, "ㅣ히히", 1, 1, "2024-08-10 10:30:00", "2024-08-12 10:30:00", "www.banner2.com", json_object('main', 'www.event1.com')),
+       (3, 1, "퀴즈 시러", 1, 1, "2024-08-13 10:30:00", "2024-08-14 10:30:00", "www.banner3.com", json_object('main', 'www.event1.com'));
 
 INSERT INTO Quizzes (sequence, sub_event_id, prize_id, anchor, answer, hint, problem, winners, winner_count, init_consonant, car_info)
 values (1, 1, 1, "#sub1", "10.4", "10 근처", "산타페의 연비는?", 2, 1, "ㅅㅈㅅ", "산타페의 선루프는...."),

--- a/src/test/resources/sql/integration.sql
+++ b/src/test/resources/sql/integration.sql
@@ -15,9 +15,9 @@ INSERT INTO events (id, end_at, event_name, event_registered_at, event_status, s
 values (1, "2024-07-01 10:00:00", "별 헤는 밤", "2024-06-28 00:00:00", 0, "2024-06-25 10:00:00", 10, 1);
 
 INSERT INTO sub_events (id, event_id, alias, execute_type, event_type, start_at, end_at, banner_img_url, event_img_urls)
-values (1, 1, "퀴즈 테스트", 1, 1, "2024-06-25 10:30:00", "2024-06-26 10:30:00", "www.banner1.com", "www.event1.com"),
-       (2, 1, "ㅣ히히", 1, 1, "2024-06-27 10:30:00", "2024-06-28 10:30:00", "www.banner2.com", "www.event2.com"),
-       (3, 1, "퀴즈 시러", 1, 1, "2024-06-29 10:30:00", "2024-06-30 10:30:00", "www.banner3.com", "www.event3.com");
+values (1, 1, "퀴즈 테스트", 1, 1, "2024-06-25 10:30:00", "2024-06-26 10:30:00", "www.banner1.com", json_object('main', 'www.event1.com')),
+       (2, 1, "ㅣ히히", 1, 1, "2024-06-27 10:30:00", "2024-06-28 10:30:00", "www.banner2.com", json_object('main', 'www.event1.com')),
+       (3, 1, "퀴즈 시러", 1, 1, "2024-06-29 10:30:00", "2024-06-30 10:30:00", "www.banner3.com", json_object('main', 'www.event1.com'));
 
 INSERT INTO Quizzes (sequence, sub_event_id, prize_id, anchor, answer, hint, problem, winners, winner_count, init_consonant, car_info)
 values (1, 1, 1, "#sub1", "10.4", "10 근처", "산타페의 연비는?", 2, 1, "ㅅㅈㅅ", "산타페의 선루프는...."),


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #84 
### 💡 작업동기
- event_img_urls가 json이 아닌 문자열 그대로 가는 문제가 있음.

### 🔑 주요 변경사항
- mysql에서 event_img_urls 컬럼을 JSON 타입으로 변경
- SubEvent 엔티티의 eventImgUrls 필드를 Map<String, Object>로 변경

### 🏞 스크린샷
<img width="399" alt="image" src="https://github.com/user-attachments/assets/3cd20323-bfe3-485e-b63a-a466c9c77852">

### 관련 이슈
- 관련 이슈를 입력해주세요.
