### PR TITLE
eventId를 쿼리 파라미터로 받지 않게 수정

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/controller/ExpectationController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/controller/ExpectationController.java
@@ -101,6 +101,6 @@ public class ExpectationController {
     ) {
         expectationService.expectationRegisterApi(expectationRegisterRequest, eventId, authenticatedUser);
 
-        return new BaseResponse<>(201, "기대평 생성되었습니다.", null);
+        return new BaseResponse<>(HttpStatus.CREATED.value(), "기대평 생성되었습니다.", null);
     }
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/controller/ExpectationController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/controller/ExpectationController.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.Null;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -31,6 +32,9 @@ import org.springframework.web.bind.annotation.*;
 public class ExpectationController {
 
     private final ExpectationService expectationService;
+
+    @Value("${properties.event-id}")
+    private Long eventId;
 
     @Operation(summary = "기대평 랜딩 페이지 api", description = """
     기대평 페이지의 데이터를 반환하는 api
@@ -46,10 +50,8 @@ public class ExpectationController {
             @ApiResponse(responseCode = "404", description = "해당하는 이벤트가 존재하지 않는 경우", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class))}),
     })
     @GetMapping("/api/v1/expectation/land")
-    public BaseResponse<ExpectationPageResponseDto> expectationLandApi(
-            @ModelAttribute @Validated ExpectationPageRequest expectationRequest
-    ) {
-        ExpectationPageResponseDto expectationPage = expectationService.getExpectationPage(expectationRequest);
+    public BaseResponse<ExpectationPageResponseDto> expectationLandApi() {
+        ExpectationPageResponseDto expectationPage = expectationService.getExpectationPage(eventId);
 
         return new BaseResponse<>(expectationPage);
     }
@@ -76,7 +78,7 @@ public class ExpectationController {
     public BaseResponse<ExpectationsResponseDto> expectationsApi(
             @ModelAttribute @Validated ExpectationsRequest expectationsRequest
     ) {
-        ExpectationsResponseDto expectations = expectationService.getExpectations(expectationsRequest);
+        ExpectationsResponseDto expectations = expectationService.getExpectations(expectationsRequest, eventId);
         return new BaseResponse<>(expectations);
     }
 
@@ -97,8 +99,8 @@ public class ExpectationController {
             @RequestBody @Validated ExpectationRegisterRequest expectationRegisterRequest,
             @Parameter(hidden = true) @CurrentUser User authenticatedUser
     ) {
-        expectationService.expectationRegisterApi(expectationRegisterRequest, authenticatedUser);
+        expectationService.expectationRegisterApi(expectationRegisterRequest, eventId, authenticatedUser);
 
-        return new BaseResponse<>(null);
+        return new BaseResponse<>(201, "기대평 생성되었습니다.", null);
     }
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationRegisterRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationRegisterRequest.java
@@ -4,15 +4,14 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ExpectationRegisterRequest {
-
-    @NotBlank
-    private Long eventId;
-
     @NotBlank
     @Max(300)
     private String comment;

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationsRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationsRequest.java
@@ -15,8 +15,4 @@ public class ExpectationsRequest {
     @NotBlank
     @Parameter
     private int pageSequence;
-
-    @NotBlank
-    @Parameter
-    private Long eventId;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/service/ExpectationService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/service/ExpectationService.java
@@ -29,9 +29,7 @@ public class ExpectationService {
     private final EventRepository eventRepository;
 
     @Transactional(readOnly = true)
-    public ExpectationPageResponseDto getExpectationPage(ExpectationPageRequest expectationPageRequest) {
-        Long eventId = expectationPageRequest.getEventId();
-
+    public ExpectationPageResponseDto getExpectationPage(long eventId) {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventNotFoundException());
 
@@ -39,7 +37,7 @@ public class ExpectationService {
     }
 
     @Transactional(readOnly = true)
-    public ExpectationsResponseDto getExpectations(ExpectationsRequest expectationsRequest) {
+    public ExpectationsResponseDto getExpectations(ExpectationsRequest expectationsRequest, long eventId) {
         Sort sort = Sort.by("createdAt").descending();
 
         Pageable pageable = PageRequest.of(
@@ -49,7 +47,7 @@ public class ExpectationService {
         );
 
         Page<Expectation> expectationPage = expectationRepository.findByEventId(
-                expectationsRequest.getEventId(),
+                eventId,
                 pageable
         );
 
@@ -77,11 +75,10 @@ public class ExpectationService {
     @Transactional
     public Expectation expectationRegisterApi(
             ExpectationRegisterRequest expectationRegisterRequest,
+            long eventId,
             User authenticatedUser
     ) {
         Expectation expectation = new Expectation();
-
-        long eventId = expectationRegisterRequest.getEventId();
 
         expectation.setEvent(eventRepository.getReferenceById(eventId));
         expectation.setUser(authenticatedUser);

--- a/src/main/resources/sql/integration.sql
+++ b/src/main/resources/sql/integration.sql
@@ -15,7 +15,7 @@ INSERT INTO events (id, end_at, event_name, event_registered_at, event_status, s
 values (1, "2024-09-01 10:00:00", "별 헤는 밤", "2024-06-28 00:00:00", 0, "2024-08-01 10:00:00", 10, 1);
 
 INSERT INTO sub_events (id, event_id, alias, execute_type, event_type, start_at, end_at, banner_img_url, event_img_urls)
-values (1, 1, "퀴즈 테스트", 1, 1, "2024-08-06 10:30:00", "2024-08-08 10:30:00", "www.banner1.com", json_object('main', 'www.event1.com')),
+values (1, 1, "퀴즈 테스트", 1, 1, "2024-08-06 10:30:00", "2024-08-09 10:30:00", "www.banner1.com", json_object('main', 'www.event1.com')),
        (2, 1, "ㅣ히히", 1, 1, "2024-08-10 10:30:00", "2024-08-12 10:30:00", "www.banner2.com", json_object('main', 'www.event1.com')),
        (3, 1, "퀴즈 시러", 1, 1, "2024-08-13 10:30:00", "2024-08-14 10:30:00", "www.banner3.com", json_object('main', 'www.event1.com'));
 
@@ -24,10 +24,10 @@ values (1, 1, 1, "#sub1", "10.4", "10 근처", "산타페의 연비는?", 2, 1, 
        (2, 2, 2, "#sub2", "11.5", "11 근처", "산타페의 연비는?", 3, 3, "ㅅㅇㅈㅇ", "산파페의 엔진은.."),
        (3, 3, 3, "#sub3", "12.5", "12 근처", "산타페의 연비는?", 12, 9, "ㅅㅇㅈㅇ", "산타페의 가격은..");
 
-INSERT INTO Winners (prize_id, sub_event_id, user_id)
-values (1, 3, 1),
-       (2, 2, 2),
-       (3, 1, 3);
+INSERT INTO Winners (id, prize_id, sub_event_id, user_id, ranking)
+VALUES (1, 1, 3, 1, 1),
+       (2, 2, 2, 2, 2),
+       (3, 3, 1, 3, 3);
 
 INSERT INTO expectations (event_id, user_id, expectation_comment, created_at, modified_at)
 values (1, 1, "기대됩니다.", "2024-07-01 10:00:00", "2024-07-01 10:00:00"),

--- a/src/test/java/com/hyundai/softeer/backend/domain/expectation/service/ExpectationServiceTest.java
+++ b/src/test/java/com/hyundai/softeer/backend/domain/expectation/service/ExpectationServiceTest.java
@@ -53,17 +53,17 @@ class ExpectationServiceTest {
     void expectationTest() {
         // given
         int pageNumber = 0;
+        long eventId = 1L;
         ExpectationPageResponseDto expectationPageResponseDto = new ExpectationPageResponseDto(
                 "www.naver.com"
         );
 
         Event event = new Event();
         event.setExpectationBannerImgUrl("www.eBanner.com");
-        ExpectationPageRequest expectationPageRequest = new ExpectationPageRequest(1L);
         when(eventRepository.findById(any(Long.class))).thenReturn(Optional.of(event));
 
         // when
-        ExpectationPageResponseDto expectationPage = expectationService.getExpectationPage(expectationPageRequest);
+        ExpectationPageResponseDto expectationPage = expectationService.getExpectationPage(eventId);
 
         // then
         assertThat(expectationPage.getExpectationBannerImgUrl()).isEqualTo(event.getExpectationBannerImgUrl());
@@ -74,6 +74,7 @@ class ExpectationServiceTest {
     void expectationNotExistEventTest() {
         // given
         int pageNumber = 0;
+        long eventId = 1L;
         ExpectationPageResponseDto expectationPageResponseDto = new ExpectationPageResponseDto(
                 "www.naver.com"
         );
@@ -83,7 +84,7 @@ class ExpectationServiceTest {
 
         // when
         Assertions.assertThatThrownBy(() -> {
-            expectationService.getExpectationPage(expectationPageRequest);
+            expectationService.getExpectationPage(eventId);
         }).isInstanceOf(EventNotFoundException.class);
     }
 
@@ -105,10 +106,10 @@ class ExpectationServiceTest {
         Page<Expectation> pages = new PageImpl<>(expectations, pageable, 22);
 
         when(expectationRepository.findByEventId(any(Long.class), any(Pageable.class))).thenReturn(pages);
-        ExpectationsRequest expectationsRequest = new ExpectationsRequest(1, 1L);
+        ExpectationsRequest expectationsRequest = new ExpectationsRequest(1);
 
         // when
-        ExpectationsResponseDto expectationsDto = expectationService.getExpectations(expectationsRequest);
+        ExpectationsResponseDto expectationsDto = expectationService.getExpectations(expectationsRequest, 1L);
 
         // then
         assertThat(expectationsDto.getTotalPages()).isEqualTo(2);
@@ -129,11 +130,11 @@ class ExpectationServiceTest {
         Page<Expectation> pages = new PageImpl<>(new ArrayList<>(), pageable, 0);
 
         when(expectationRepository.findByEventId(any(Long.class), any(Pageable.class))).thenReturn(pages);
-        ExpectationsRequest expectationsRequest = new ExpectationsRequest(1, 1L);
+        ExpectationsRequest expectationsRequest = new ExpectationsRequest(1);
 
         // when
         Assertions.assertThatThrownBy(() -> {
-            expectationService.getExpectations(expectationsRequest);
+            expectationService.getExpectations(expectationsRequest, 1L);
         }).isInstanceOf(ExpectationNotFoundException.class);
     }
 
@@ -143,7 +144,7 @@ class ExpectationServiceTest {
         // Arrange
         long eventId = 1L;
         String comment = "Test comment";
-        ExpectationRegisterRequest request = new ExpectationRegisterRequest(eventId, comment);
+        ExpectationRegisterRequest request = new ExpectationRegisterRequest(comment);
         User authenticatedUser = User.builder()
                 .name("김민준")
                 .email("minjun@naver.com")
@@ -160,7 +161,7 @@ class ExpectationServiceTest {
         when(expectationRepository.save(any(Expectation.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // Act
-        Expectation result = expectationService.expectationRegisterApi(request, authenticatedUser);
+        Expectation result = expectationService.expectationRegisterApi(request, eventId, authenticatedUser);
         Event resultEvent = result.getEvent();
         User resultUser = result.getUser();
 

--- a/src/test/resources/sql/integration.sql
+++ b/src/test/resources/sql/integration.sql
@@ -24,10 +24,10 @@ values (1, 1, 1, "#sub1", "10.4", "10 근처", "산타페의 연비는?", 2, 1, 
        (2, 2, 2, "#sub2", "11.5", "11 근처", "산타페의 연비는?", 3, 3, "ㅅㅇㅈㅇ", "산파페의 엔진은.."),
        (3, 3, 3, "#sub3", "12.5", "12 근처", "산타페의 연비는?", 12, 9, "ㅅㅇㅈㅇ", "산타페의 가격은..");
 
-INSERT INTO Winners (prize_id, sub_event_id, user_id)
-values (1, 3, 1),
-       (2, 2, 2),
-       (3, 1, 3);
+INSERT INTO Winners (id, prize_id, sub_event_id, user_id, ranking)
+VALUES (1, 1, 3, 1, 1),
+       (2, 2, 2, 2, 2),
+       (3, 3, 1, 3, 3);
 
 INSERT INTO expectations (event_id, user_id, expectation_comment, created_at, modified_at)
 values (1, 1, "기대됩니다.", "2024-07-01 10:00:00", "2024-07-01 10:00:00"),


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #104 

### 💡 작업동기
- 프로젝트 계획이 수정되면서 event 식별자를 서버에서 보관

### 🔑 주요 변경사항
- application.yml에서 eventId 추출
- ranking 컬럼 .sql 파일에 추가

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- 관련 이슈를 입력해주세요.
