### PR TITLE
api 경로 수정 및 예외 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 

--- a/src/main/java/com/hyundai/softeer/backend/domain/event/dto/EventRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/event/dto/EventRequest.java
@@ -2,14 +2,11 @@ package com.hyundai.softeer.backend.domain.event.dto;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springdoc.core.annotations.ParameterObject;
 
-@Getter
-@Setter
-@AllArgsConstructor
+@Data
+@NoArgsConstructor
 @ParameterObject
 public class EventRequest {
     @NotBlank

--- a/src/main/java/com/hyundai/softeer/backend/domain/eventuser/dto/EventUserInfoRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/eventuser/dto/EventUserInfoRequest.java
@@ -1,13 +1,20 @@
 package com.hyundai.softeer.backend.domain.eventuser.dto;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springdoc.core.annotations.ParameterObject;
 
-@Getter
+@Data
 @NoArgsConstructor
+@ParameterObject
 public class EventUserInfoRequest {
 
-    @NotBlank
+    @Parameter
+    @NotNull
     private Long subEventId;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/controller/ExpectationController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/controller/ExpectationController.java
@@ -49,7 +49,7 @@ public class ExpectationController {
             @ApiResponse(responseCode = "400", description = "쿼리 파라미터의 타입이 잘못되었거나 존재하지 않을 때", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "해당하는 이벤트가 존재하지 않는 경우", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class))}),
     })
-    @GetMapping("/api/v1/expectation/land")
+    @GetMapping("/api/v1/expectation")
     public BaseResponse<ExpectationPageResponseDto> expectationLandApi() {
         ExpectationPageResponseDto expectationPage = expectationService.getExpectationPage(eventId);
 
@@ -76,7 +76,7 @@ public class ExpectationController {
     })
     @GetMapping("/api/v1/expectation/page")
     public BaseResponse<ExpectationsResponseDto> expectationsApi(
-            @ModelAttribute @Validated ExpectationsRequest expectationsRequest
+            @Validated ExpectationsRequest expectationsRequest
     ) {
         ExpectationsResponseDto expectations = expectationService.getExpectations(expectationsRequest, eventId);
         return new BaseResponse<>(expectations);
@@ -93,7 +93,7 @@ public class ExpectationController {
             @ApiResponse(responseCode = "201", description = "정상 반환 시", useReturnTypeSchema = true),
             @ApiResponse(responseCode = "400", description = "쿼리 파라미터의 타입이 잘못되었거나 존재하지 않을 때", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class))}),
     })
-    @PostMapping("/api/v1/expectation/register")
+    @PostMapping("/api/v1/expectation")
     @ResponseStatus(HttpStatus.CREATED)
     public BaseResponse<Null> expectationRegisterApi(
             @RequestBody @Validated ExpectationRegisterRequest expectationRegisterRequest,

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationContentDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationContentDto.java
@@ -9,5 +9,5 @@ import lombok.*;
 @Setter
 public class ExpectationContentDto {
     private final String name;
-    private final String expectationComment;
+    private final String comment;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationPageRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationPageRequest.java
@@ -2,17 +2,15 @@ package com.hyundai.softeer.backend.domain.expectation.dto;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 import org.springdoc.core.annotations.ParameterObject;
 
-@Getter
-@Setter
-@AllArgsConstructor
+@Data
+@NoArgsConstructor
 @ParameterObject
 public class ExpectationPageRequest {
-    @NotBlank
+    @NotNull
     @Parameter
     private Long eventId;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationPageResponseDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationPageResponseDto.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class ExpectationPageResponseDto {
-    private String expectationBannerImgUrl;
+    private String bannerImgUrl;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationRegisterRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationRegisterRequest.java
@@ -1,18 +1,19 @@
 package com.hyundai.softeer.backend.domain.expectation.dto;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.springdoc.core.annotations.ParameterObject;
 
-@Getter
-@Setter
+@Data
 @NoArgsConstructor
-@AllArgsConstructor
+@ParameterObject
 public class ExpectationRegisterRequest {
+
+    @Parameter
     @NotBlank
-    @Max(300)
+    @Size(max=300)
     private String comment;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationRegisterRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationRegisterRequest.java
@@ -1,18 +1,13 @@
 package com.hyundai.softeer.backend.domain.expectation.dto;
 
-import io.swagger.v3.oas.annotations.Parameter;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
-import org.springdoc.core.annotations.ParameterObject;
 
 @Data
 @NoArgsConstructor
-@ParameterObject
 public class ExpectationRegisterRequest {
 
-    @Parameter
     @NotBlank
     @Size(max=300)
     private String comment;

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationsRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationsRequest.java
@@ -2,17 +2,17 @@ package com.hyundai.softeer.backend.domain.expectation.dto;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 import org.springdoc.core.annotations.ParameterObject;
 
-@Getter
-@Setter
+@Data
 @AllArgsConstructor
+@NoArgsConstructor
 @ParameterObject
 public class ExpectationsRequest {
-    @NotBlank
+
+    @NotNull
     @Parameter
-    private int pageSequence;
+    private Integer pageSequence;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationsResponseDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/expectation/dto/ExpectationsResponseDto.java
@@ -10,5 +10,5 @@ import java.util.List;
 public class ExpectationsResponseDto {
 
     private int totalPages;
-    private List<ExpectationContentDto> expectationContents;
+    private List<ExpectationContentDto> comments;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/controller/QuizController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/controller/QuizController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -48,9 +49,9 @@ public class QuizController {
             @ApiResponse(responseCode = "401", description = "로그인x", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class), examples = @ExampleObject("{\"message\":\"로그인이 되지 않았습니다.\",\"status\":401}"))}),
             @ApiResponse(responseCode = "404", description = "퀴즈x", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class), examples = @ExampleObject("{\"message\":\"퀴즈 이벤트가 존재하지 않습니다.\",\"status\":404}"))})
     })
-    @GetMapping("/api/v1/quiz")
+    @GetMapping("/api/v1/quiz/info")
     public BaseResponse<QuizResponseDto> getQuiz(
-            @Validated  QuizRequest quizRequest
+            @ModelAttribute @Valid QuizRequest quizRequest
     ) {
         QuizResponseDto quizResponse = quizService.getQuiz(quizRequest);
 
@@ -75,7 +76,7 @@ public class QuizController {
             @ApiResponse(responseCode = "400", description = "GET 요청의 query parameter가 숫자가 아니거나 존재하지 않을 때", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class), examples = @ExampleObject("{\"message\":\"존재하지 않는 이벤트 정보입니다.\",\"status\":400}"))}),
             @ApiResponse(responseCode = "404", description = "해당하는 이벤트나 현재 진행 중인 퀴즈 이벤트가 존재하지 않을 경우", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class), examples = @ExampleObject("{\"message\":\"퀴즈 이벤트가 존재하지 않습니다.\",\"status\":404}"))})
     })
-    @GetMapping("/api/v1/quiz/land")
+    @GetMapping("/api/v1/quiz")
     public BaseResponse<QuizLandResponseDto> getQuizLandingPage() {
         QuizLandResponseDto getQuizResponseDto = quizService.getQuizLand(eventId);
         return new BaseResponse<>(getQuizResponseDto);
@@ -100,12 +101,12 @@ public class QuizController {
                     useReturnTypeSchema = true),
             @ApiResponse(responseCode = "400", description = "쿼리 파라미터를 잘못 보냈을 때", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class))}),
     })
-    @PostMapping("/api/v1/quiz/submit")
+    @PostMapping("/api/v1/quiz")
     public BaseResponse<QuizSubmitResponseDto> quizSubmit(
             @RequestBody @Validated QuizSubmitRequest quizSubmitRequest,
             @Parameter(hidden = true) @CurrentUser User user
     ) {
-        QuizSubmitResponseDto quizSubmitResponseDto = quizService.quizSubmit(quizSubmitRequest, user);
+        quizService.quizSubmit(quizSubmitRequest, user);
 
         return BaseResponse.<QuizSubmitResponseDto>builder()
                 .data(null)

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/controller/QuizController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/controller/QuizController.java
@@ -106,10 +106,10 @@ public class QuizController {
             @RequestBody @Validated QuizSubmitRequest quizSubmitRequest,
             @Parameter(hidden = true) @CurrentUser User user
     ) {
-        quizService.quizSubmit(quizSubmitRequest, user);
+        QuizSubmitResponseDto quizSubmitResponseDto = quizService.quizSubmit(quizSubmitRequest, user);
 
         return BaseResponse.<QuizSubmitResponseDto>builder()
-                .data(null)
+                .data(quizSubmitResponseDto)
                 .status(HttpStatus.CREATED.value())
                 .message(HttpStatus.CREATED.getReasonPhrase())
                 .build();

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/dto/QuizRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/dto/QuizRequest.java
@@ -1,14 +1,18 @@
 package com.hyundai.softeer.backend.domain.firstcomeevent.quiz.dto;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.springdoc.core.annotations.ParameterObject;
 
-@Getter
-@NoArgsConstructor
+@Data
 @AllArgsConstructor
+@NoArgsConstructor
+@ParameterObject
 public class QuizRequest {
-    @NotBlank
-    private long subEventId;
+
+    @Parameter
+    @NotNull
+    private Long subEventId;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/dto/QuizSubmitRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/dto/QuizSubmitRequest.java
@@ -8,14 +8,11 @@ import org.springdoc.core.annotations.ParameterObject;
 
 @Data
 @NoArgsConstructor
-@ParameterObject
 public class QuizSubmitRequest {
 
-    @Parameter
     @NotBlank
     private String answer;
 
-    @Parameter
     @NotNull
     private Long subEventId;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/dto/QuizSubmitRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/dto/QuizSubmitRequest.java
@@ -1,17 +1,21 @@
 package com.hyundai.softeer.backend.domain.firstcomeevent.quiz.dto;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.springdoc.core.annotations.ParameterObject;
 
-@Getter
+@Data
 @NoArgsConstructor
-@AllArgsConstructor
+@ParameterObject
 public class QuizSubmitRequest {
+
+    @Parameter
     @NotBlank
     private String answer;
 
-    @NotBlank
+    @Parameter
+    @NotNull
     private Long subEventId;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/entity/Quiz.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/entity/Quiz.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "firstcomes")
+@Table(name = "quiz_firstcome_events")
 @SuperBuilder
 @NoArgsConstructor
 @Getter

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/entity/Quiz.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/entity/Quiz.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "Quizzes")
+@Table(name = "firstcomes")
 @SuperBuilder
 @NoArgsConstructor
 @Getter

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/service/QuizService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcomeevent/quiz/service/QuizService.java
@@ -56,8 +56,6 @@ public class QuizService {
     public QuizResponseDto getQuiz(QuizRequest quizRequest) {
         Long subEventId = quizRequest.getSubEventId();
 
-        Optional<Quiz> optionalQuiz = quizRepository.findBySubEventId(subEventId);
-
         Quiz quiz = quizRepository.findBySubEventId(subEventId)
                 .orElseThrow(() -> new QuizNotFoundException());
 

--- a/src/main/java/com/hyundai/softeer/backend/domain/subevent/dto/SubEventRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/subevent/dto/SubEventRequest.java
@@ -3,13 +3,12 @@ package com.hyundai.softeer.backend.domain.subevent.dto;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import org.springdoc.core.annotations.ParameterObject;
 
-@Getter
-@Setter
-@AllArgsConstructor
+@Data
 @ParameterObject
 public class SubEventRequest {
     @NotBlank

--- a/src/main/resources/sql/integration.sql
+++ b/src/main/resources/sql/integration.sql
@@ -19,7 +19,7 @@ values (1, 1, "퀴즈 테스트", 1, 1, "2024-08-06 10:30:00", "2024-08-09 10:30
        (2, 1, "ㅣ히히", 1, 1, "2024-08-10 10:30:00", "2024-08-12 10:30:00", "www.banner2.com", json_object('main', 'www.event1.com')),
        (3, 1, "퀴즈 시러", 1, 1, "2024-08-13 10:30:00", "2024-08-14 10:30:00", "www.banner3.com", json_object('main', 'www.event1.com'));
 
-INSERT INTO Quizzes (sequence, sub_event_id, prize_id, anchor, answer, hint, problem, winners, winner_count, init_consonant, car_info)
+INSERT INTO quiz_firstcome_events (sequence, sub_event_id, prize_id, anchor, answer, hint, problem, winners, winner_count, init_consonant, car_info)
 values (1, 1, 1, "#sub1", "10.4", "10 근처", "산타페의 연비는?", 2, 1, "ㅅㅈㅅ", "산타페의 선루프는...."),
        (2, 2, 2, "#sub2", "11.5", "11 근처", "산타페의 연비는?", 3, 3, "ㅅㅇㅈㅇ", "산파페의 엔진은.."),
        (3, 3, 3, "#sub3", "12.5", "12 근처", "산타페의 연비는?", 12, 9, "ㅅㅇㅈㅇ", "산타페의 가격은..");

--- a/src/test/java/com/hyundai/softeer/backend/domain/expectation/service/ExpectationServiceTest.java
+++ b/src/test/java/com/hyundai/softeer/backend/domain/expectation/service/ExpectationServiceTest.java
@@ -66,7 +66,7 @@ class ExpectationServiceTest {
         ExpectationPageResponseDto expectationPage = expectationService.getExpectationPage(eventId);
 
         // then
-        assertThat(expectationPage.getExpectationBannerImgUrl()).isEqualTo(event.getExpectationBannerImgUrl());
+        assertThat(expectationPage.getBannerImgUrl()).isEqualTo(event.getExpectationBannerImgUrl());
     }
 
     @Test
@@ -80,7 +80,7 @@ class ExpectationServiceTest {
         );
 
         when(eventRepository.findById(any(Long.class))).thenReturn(Optional.empty());
-        ExpectationPageRequest expectationPageRequest = new ExpectationPageRequest(100L);
+        ExpectationPageRequest expectationPageRequest = new ExpectationPageRequest();
 
         // when
         Assertions.assertThatThrownBy(() -> {
@@ -113,7 +113,7 @@ class ExpectationServiceTest {
 
         // then
         assertThat(expectationsDto.getTotalPages()).isEqualTo(2);
-        assertThat(expectationsDto.getExpectationContents()).containsExactlyElementsOf(expectationContentDtos);
+        assertThat(expectationsDto.getComments()).containsExactlyElementsOf(expectationContentDtos);
     }
 
     @Test
@@ -144,7 +144,7 @@ class ExpectationServiceTest {
         // Arrange
         long eventId = 1L;
         String comment = "Test comment";
-        ExpectationRegisterRequest request = new ExpectationRegisterRequest(comment);
+        ExpectationRegisterRequest request = new ExpectationRegisterRequest();
         User authenticatedUser = User.builder()
                 .name("김민준")
                 .email("minjun@naver.com")

--- a/src/test/resources/sql/integration-h2.sql
+++ b/src/test/resources/sql/integration-h2.sql
@@ -23,7 +23,7 @@ VALUES (1, 1, '퀴즈 테스트', 1, 1, '2024-06-25 10:30:00', '2024-06-26 10:30
         JSON '{"main": "www.event1.com"}');
 
 
-INSERT INTO Quizzes (sequence, sub_event_id, prize_id, anchor, answer, hint, problem, winners, winner_count,
+INSERT INTO quiz_firstcome_events (sequence, sub_event_id, prize_id, anchor, answer, hint, problem, winners, winner_count,
                      init_consonant, car_info)
 VALUES (1, 1, 1, '#sub1', '10.4', '10 근처', '산타페의 연비는?', 2, 1, 'ㅅㅈㅅ', '산타페의 선루프는....'),
        (2, 2, 2, '#sub2', '11.5', '11 근처', '산타페의 연비는?', 3, 3, 'ㅅㅇㅈㅇ', '산타페의 엔진은..'),

--- a/src/test/resources/sql/integration.sql
+++ b/src/test/resources/sql/integration.sql
@@ -19,7 +19,7 @@ values (1, 1, "퀴즈 테스트", 1, 1, "2024-06-25 10:30:00", "2024-06-26 10:30
        (2, 1, "ㅣ히히", 1, 1, "2024-06-27 10:30:00", "2024-06-28 10:30:00", "www.banner2.com", json_object('main', 'www.event1.com')),
        (3, 1, "퀴즈 시러", 1, 1, "2024-06-29 10:30:00", "2024-06-30 10:30:00", "www.banner3.com", json_object('main', 'www.event1.com'));
 
-INSERT INTO Quizzes (sequence, sub_event_id, prize_id, anchor, answer, hint, problem, winners, winner_count, init_consonant, car_info)
+INSERT INTO quiz_firstcome_events (sequence, sub_event_id, prize_id, anchor, answer, hint, problem, winners, winner_count, init_consonant, car_info)
 values (1, 1, 1, "#sub1", "10.4", "10 근처", "산타페의 연비는?", 2, 1, "ㅅㅈㅅ", "산타페의 선루프는...."),
        (2, 2, 2, "#sub2", "11.5", "11 근처", "산타페의 연비는?", 3, 3, "ㅅㅇㅈㅇ", "산파페의 엔진은.."),
        (3, 3, 3, "#sub3", "12.5", "12 근처", "산타페의 연비는?", 12, 9, "ㅅㅇㅈㅇ", "산타페의 가격은..");


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #104
### 💡 작업동기
- api query parameter 키 값이 너무 긴 문제
- api가 restful하지 않음
- validation이 제대로 동작하지 않음
- quiz api 경로 앞에 firstcome 

### 🔑 주요 변경사항
- api 경로 수정
    - GET api/v1/quiz/land -> api/v1/firstcome/quiz
    - GET api/v1/quiz/ -> api/v1/firstcome/quiz/info
    - POST api/v1/quiz/register -> api/v1/firstcome/quiz
    - GET api/v1/expectation/land -> api/v1/expectation
    - POST api/v1/expectation/register -> api/v1/expectation
    
- validation 적용
    - @Validated를 이용한 유효성 검사 적용

- 테이블명 수정
    - Quizzes 테이블을 quiz_firstcome_events로 수정
### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- 관련 이슈를 입력해주세요.
