### PR TITLE
중복 당첨자 검사할 수 있는 로직 추가

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/dto/QuizFirstComeSubmitResponseDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/dto/QuizFirstComeSubmitResponseDto.java
@@ -10,17 +10,22 @@ import lombok.Getter;
 public class QuizFirstComeSubmitResponseDto {
     private Boolean isCorrect;
     private Boolean isWinner;
+    private Boolean isParticipant;
     private String prizeImgUrl;
 
     public static QuizFirstComeSubmitResponseDto winner(String prizeImgUrl) {
-        return new QuizFirstComeSubmitResponseDto(true, true, prizeImgUrl);
+        return new QuizFirstComeSubmitResponseDto(true, true, false, prizeImgUrl);
     }
 
     public static QuizFirstComeSubmitResponseDto correctBut() {
-        return new QuizFirstComeSubmitResponseDto(true, false, null);
+        return new QuizFirstComeSubmitResponseDto(true, false, false, null);
     }
 
     public static QuizFirstComeSubmitResponseDto notCorrect() {
-        return new QuizFirstComeSubmitResponseDto(false, false, null);
+        return new QuizFirstComeSubmitResponseDto(false, false, false, null);
+    }
+
+    public static QuizFirstComeSubmitResponseDto alreadyParticipant() {
+        return new QuizFirstComeSubmitResponseDto(false, false, true, null);
     }
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/winner/repository/WinnerRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/winner/repository/WinnerRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface WinnerRepository extends JpaRepository<Winner, Long> {
     Optional<List<Winner>> findBySubEventId(Long subEventId);
+
+    Optional<Winner> findByUserIdAndSubEventId(Long userId, Long subEventId);
 }

--- a/src/main/java/com/hyundai/softeer/backend/global/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/hyundai/softeer/backend/global/filter/RequestLoggingFilter.java
@@ -1,0 +1,21 @@
+package com.hyundai.softeer.backend.global.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class RequestLoggingFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+        log.debug("request uri = {} method = {}", httpServletRequest.getRequestURI(), httpServletRequest.getMethod());
+
+        chain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #123 

### 💡 작업동기
- 중복 당첨자가 게임을 다시할 수 있음

### 🔑 주요 변경사항
- 중복 당첨자가 게임을 다시하지 못하게 검사를 수행

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- 관련 이슈를 입력해주세요.
