### PR TITLE
메인 랜딩 페이지 퀴즈 시작 시간 정보 제공

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/event/controller/MainController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/event/controller/MainController.java
@@ -38,7 +38,36 @@ public class MainController {
             - 정상 반환 시 `200`이 반환됩니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "정상 반환 시", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "200", description = "정상 반환 시", useReturnTypeSchema = true, content = {@Content(examples = @ExampleObject("{\n" +
+                    "    \"status\": 200,\n" +
+                    "    \"message\": \"OK\",\n" +
+                    "    \"data\": {\n" +
+                    "        \"remainSecond\": 0,\n" +
+                    "        \"imgs\": {\n" +
+                    "            \"mainImgUrl\": \"www.mainimg.com\",\n" +
+                    "            \"quizMainImg\": \"www.quizmain.com\",\n" +
+                    "            \"eventInfoImg\": \"www.eventinfo.com\",\n" +
+                    "            \"quizPrizeImg\": \"www.qprize.com\",\n" +
+                    "            \"drawingMainImg\": \"www.drawingmain.com\",\n" +
+                    "            \"scrolledImgUrl\": \"www.scroll.com\",\n" +
+                    "            \"drawingPrizeImg\": \"www.drawingprize.com\"\n" +
+                    "        },\n" +
+                    "        \"quizEventStartAt\": [\n" +
+                    "            {\n" +
+                    "                \"isStarted\": true,\n" +
+                    "                \"startAt\": \"2024-08-06T10:30:00\"\n" +
+                    "            },\n" +
+                    "            {\n" +
+                    "                \"isStarted\": true,\n" +
+                    "                \"startAt\": \"2024-08-12T10:30:00\"\n" +
+                    "            },\n" +
+                    "            {\n" +
+                    "                \"isStarted\": false,\n" +
+                    "                \"startAt\": \"2024-08-19T10:30:00\"\n" +
+                    "            }\n" +
+                    "        ]\n" +
+                    "    }\n" +
+                    "}"))}),
             @ApiResponse(responseCode = "404", description = "퀴즈x", content = {@Content(schema = @Schema(implementation = ApiErrorResponse.class), examples = @ExampleObject("{\"message\":\"퀴즈 이벤트가 존재하지 않습니다.\",\"status\":404}"))})
     })
     @GetMapping("/api/v1/land")

--- a/src/main/java/com/hyundai/softeer/backend/domain/event/dto/MainLandDto.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/event/dto/MainLandDto.java
@@ -3,6 +3,7 @@ package com.hyundai.softeer.backend.domain.event.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.Map;
 
 @Builder
@@ -13,5 +14,5 @@ public class MainLandDto {
 
     private Map<String, Object> imgs;
 
-
+    private List<QuizStartInfo> quizEventStartAt;
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/event/dto/QuizStartInfo.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/event/dto/QuizStartInfo.java
@@ -1,0 +1,14 @@
+package com.hyundai.softeer.backend.domain.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class QuizStartInfo {
+    Boolean isStarted;
+
+    LocalDateTime startAt;
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/event/service/MainService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/event/service/MainService.java
@@ -1,16 +1,19 @@
 package com.hyundai.softeer.backend.domain.event.service;
 
+import com.hyundai.softeer.backend.domain.event.dto.QuizStartInfo;
 import com.hyundai.softeer.backend.domain.event.entity.Event;
 import com.hyundai.softeer.backend.domain.event.exception.EventNotFoundException;
 import com.hyundai.softeer.backend.domain.event.repository.EventRepository;
 import com.hyundai.softeer.backend.domain.event.dto.MainLandDto;
 import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import com.hyundai.softeer.backend.domain.subevent.enums.SubEventExecuteType;
 import com.hyundai.softeer.backend.domain.subevent.exception.SubEventNotFoundException;
 import com.hyundai.softeer.backend.domain.subevent.repository.SubEventRepository;
 import com.hyundai.softeer.backend.global.utils.DateUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -36,11 +39,26 @@ public class MainService {
            throw new SubEventNotFoundException();
         }
 
+        List<SubEvent> quizEvents = subEventRepository.findByEventIdAndExecuteType(eventId, SubEventExecuteType.FIRSTCOME);
+
+        if(quizEvents.isEmpty()) {
+            throw new EventNotFoundException();
+        }
+
+        List<QuizStartInfo> startAts = quizEvents.stream()
+                .map((quizEvent) -> {
+                    boolean isStarted = dateUtil.isSubEventStarted(quizEvent);
+                    LocalDateTime startAt = quizEvent.getStartAt();
+                    return new QuizStartInfo(isStarted, startAt);
+                })
+                .toList();
+
         int remainSecond = (int) dateUtil.startBetweenCurrentDiff(closestSubEvent);
 
         return MainLandDto.builder()
                 .imgs(eventImgUrls)
                 .remainSecond(remainSecond)
+                .quizEventStartAt(startAts)
                 .build();
     }
 }

--- a/src/main/java/com/hyundai/softeer/backend/global/utils/DateUtil.java
+++ b/src/main/java/com/hyundai/softeer/backend/global/utils/DateUtil.java
@@ -61,4 +61,9 @@ public class DateUtil {
         }
         return closetSubEvent;
     }
+
+    public boolean isSubEventStarted(SubEvent subEvent) {
+        LocalDateTime current = LocalDateTime.now(clock);
+        return current.isAfter(subEvent.getStartAt());
+    }
 }

--- a/src/test/java/com/hyundai/softeer/backend/domain/main/service/MainServiceTest.java
+++ b/src/test/java/com/hyundai/softeer/backend/domain/main/service/MainServiceTest.java
@@ -54,8 +54,6 @@ class MainServiceTest {
         when(dateUtil.startBetweenCurrentDiff(any(SubEvent.class))).thenReturn(1000L);
         when(subEventRepository.findByEventIdAndExecuteType(anyLong(), any(SubEventExecuteType.class))).thenReturn(SubEvent.subEventsGenerator(3L));
 
-        List<SubEvent> quizEvents = subEventRepository.findByEventIdAndExecuteType(eventId, SubEventExecuteType.FIRSTCOME);
-
         // when
         MainLandDto mainLandDto = mainService.mainLand(eventId);
 

--- a/src/test/java/com/hyundai/softeer/backend/domain/main/service/MainServiceTest.java
+++ b/src/test/java/com/hyundai/softeer/backend/domain/main/service/MainServiceTest.java
@@ -6,6 +6,7 @@ import com.hyundai.softeer.backend.domain.event.repository.EventRepository;
 import com.hyundai.softeer.backend.domain.event.dto.MainLandDto;
 import com.hyundai.softeer.backend.domain.event.service.MainService;
 import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import com.hyundai.softeer.backend.domain.subevent.enums.SubEventExecuteType;
 import com.hyundai.softeer.backend.domain.subevent.exception.SubEventNotFoundException;
 import com.hyundai.softeer.backend.domain.subevent.repository.SubEventRepository;
 import com.hyundai.softeer.backend.global.utils.DateUtil;
@@ -17,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -50,6 +52,9 @@ class MainServiceTest {
         when(subEventRepository.findByEventId(anyLong())).thenReturn(SubEvent.subEventsGenerator(3L));
         when(dateUtil.findClosestSubEvent(any(List.class))).thenReturn(SubEvent.subEventGenerator(1L));
         when(dateUtil.startBetweenCurrentDiff(any(SubEvent.class))).thenReturn(1000L);
+        when(subEventRepository.findByEventIdAndExecuteType(anyLong(), any(SubEventExecuteType.class))).thenReturn(SubEvent.subEventsGenerator(3L));
+
+        List<SubEvent> quizEvents = subEventRepository.findByEventIdAndExecuteType(eventId, SubEventExecuteType.FIRSTCOME);
 
         // when
         MainLandDto mainLandDto = mainService.mainLand(eventId);
@@ -59,6 +64,8 @@ class MainServiceTest {
         assertThat(mainLandDto.getRemainSecond()).isEqualTo(1000L);
         assertThat(mainLandDto.getImgs()).isNotNull();
         assertThat(mainLandDto.getImgs().size()).isEqualTo(7);
+        assertThat(mainLandDto.getQuizEventStartAt().get(0).getStartAt())
+                .isEqualTo(LocalDateTime.of(2024, 06, 24, 0, 0, 0).plusHours(1L));
     }
 
     @Test


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #132 

### 💡 작업동기
- 프론트와 api 연동 중에 발생한 문제

- 메인 랜딩 페이지에 퀴즈 시작 시간과 시작 여부가 없음을 확인

### 🔑 주요 변경사항
- 퀴즈 시작 시간과 시작 여부를 List로 제공

### 🏞 스크린샷
<img width="600" alt="image" src="https://github.com/user-attachments/assets/3f26b7fc-f5d7-4dcd-98c6-4b489b67703c">

### 관련 이슈
- 관련 이슈를 입력해주세요.
