### PR TITLE
[BE] 선착순 로직 추상화 및 동기화

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public class EventUser {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
     private Long id;
 
@@ -37,8 +38,7 @@ public class EventUser {
     private LocalDateTime lastChargeAt = LocalDateTime.now();
 
     @Column(unique = true)
-    @Builder.Default
-    private String sharedUrl = "";
+    private String sharedUrl;
 
     @Builder.Default
     private Double sharedScore = 0.0;

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizFirstComeService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizFirstComeService.java
@@ -210,7 +210,7 @@ public class QuizFirstComeService {
      * @return
      */
     @Transactional
-    public synchronized QuizFirstComeSubmitResponseDto quizSubmit(QuizFirstComeSubmitRequest quizFirstComeSubmitRequest, User authenticatedUser) {
+    public QuizFirstComeSubmitResponseDto quizSubmit(QuizFirstComeSubmitRequest quizFirstComeSubmitRequest, User authenticatedUser) {
 
         Long subEventId = quizFirstComeSubmitRequest.getSubEventId();
         String answer = quizFirstComeSubmitRequest.getAnswer();

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizFirstComeService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizFirstComeService.java
@@ -210,7 +210,7 @@ public class QuizFirstComeService {
      * @return
      */
     @Transactional
-    public QuizFirstComeSubmitResponseDto quizSubmit(QuizFirstComeSubmitRequest quizFirstComeSubmitRequest, User authenticatedUser) {
+    public synchronized QuizFirstComeSubmitResponseDto quizSubmit(QuizFirstComeSubmitRequest quizFirstComeSubmitRequest, User authenticatedUser) {
 
         Long subEventId = quizFirstComeSubmitRequest.getSubEventId();
         String answer = quizFirstComeSubmitRequest.getAnswer();

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDraw.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDraw.java
@@ -1,0 +1,11 @@
+package com.hyundai.softeer.backend.domain.firstcome.quiz.service;
+
+import com.hyundai.softeer.backend.domain.firstcome.quiz.dto.QuizFirstComeSubmitResponseDto;
+import com.hyundai.softeer.backend.domain.firstcome.quiz.entity.QuizFirstCome;
+import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import com.hyundai.softeer.backend.domain.user.entity.User;
+
+public interface QuizWinnerDraw {
+
+    QuizFirstComeSubmitResponseDto winnerDraw(QuizFirstCome quizFirstCome, SubEvent subEvent, User authenticatedUser);
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
@@ -24,9 +24,8 @@ public class QuizWinnerDrawSync implements QuizWinnerDraw {
     private final QuizFirstComeRepository quizFirstComeRepository;
 
     @Override
-    @Synchronized
     @Transactional
-    public QuizFirstComeSubmitResponseDto winnerDraw(
+    public synchronized QuizFirstComeSubmitResponseDto winnerDraw(
             QuizFirstCome quizFirstCome,
             SubEvent subEvent,
             User authenticatedUser) {

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
@@ -25,7 +25,7 @@ public class QuizWinnerDrawSync implements QuizWinnerDraw {
 
     @Override
     @Transactional
-    public synchronized QuizFirstComeSubmitResponseDto winnerDraw(
+    public QuizFirstComeSubmitResponseDto winnerDraw(
             QuizFirstCome quizFirstCome,
             SubEvent subEvent,
             User authenticatedUser) {

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
@@ -1,0 +1,55 @@
+package com.hyundai.softeer.backend.domain.firstcome.quiz.service;
+
+import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
+import com.hyundai.softeer.backend.domain.firstcome.quiz.dto.QuizFirstComeSubmitResponseDto;
+import com.hyundai.softeer.backend.domain.firstcome.quiz.entity.QuizFirstCome;
+import com.hyundai.softeer.backend.domain.prize.entity.Prize;
+import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
+import com.hyundai.softeer.backend.domain.subevent.repository.SubEventRepository;
+import com.hyundai.softeer.backend.domain.user.entity.User;
+import com.hyundai.softeer.backend.domain.user.repository.UserRepository;
+import com.hyundai.softeer.backend.domain.winner.entity.Winner;
+import com.hyundai.softeer.backend.domain.winner.repository.WinnerRepository;
+import com.hyundai.softeer.backend.domain.winner.utils.WinnerUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.Synchronized;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class QuizWinnerDrawSync implements QuizWinnerDraw {
+
+    private final WinnerRepository winnerRepository;
+    private final WinnerUtil winnerUtil;
+
+    @Override
+    @Synchronized
+    @Transactional
+    public QuizFirstComeSubmitResponseDto winnerDraw(
+            QuizFirstCome quizFirstCome,
+            SubEvent subEvent,
+            User authenticatedUser) {
+
+        if(!winnerUtil.isParticipanted(authenticatedUser.getId(), subEvent.getId()).isEmpty()) {
+            return QuizFirstComeSubmitResponseDto.alreadyParticipant();
+        }
+
+        int winners = quizFirstCome.getWinners();
+        int winnerCount = quizFirstCome.getWinnerCount();
+
+        if (winnerCount >= winners) {
+            return QuizFirstComeSubmitResponseDto.correctBut();
+        }
+
+        quizFirstCome.setWinnerCount(winnerCount + 1);
+
+        Prize prize = quizFirstCome.getPrize();
+
+        Winner winner = new Winner();
+        winner.setPrize(prize);
+        winner.setSubEvent(subEvent);
+        winner.setUser(authenticatedUser);
+        winnerRepository.save(winner);
+
+        return QuizFirstComeSubmitResponseDto.winner(prize.getPrizeWinningImgUrl());
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
@@ -24,8 +24,7 @@ public class QuizWinnerDrawSync implements QuizWinnerDraw {
     private final QuizFirstComeRepository quizFirstComeRepository;
 
     @Override
-    @Transactional
-    public QuizFirstComeSubmitResponseDto winnerDraw(
+    public synchronized QuizFirstComeSubmitResponseDto winnerDraw(
             QuizFirstCome quizFirstCome,
             SubEvent subEvent,
             User authenticatedUser) {
@@ -35,7 +34,7 @@ public class QuizWinnerDrawSync implements QuizWinnerDraw {
         }
 
         int winners = quizFirstCome.getWinners();
-        int winnerCount = quizFirstCome.getWinnerCount();
+        int winnerCount = (int) winnerRepository.countWinnerBySubEventId(subEvent.getId());
 
         if (winnerCount >= winners) {
             return QuizFirstComeSubmitResponseDto.correctBut();

--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizWinnerDrawSync.java
@@ -3,6 +3,7 @@ package com.hyundai.softeer.backend.domain.firstcome.quiz.service;
 import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
 import com.hyundai.softeer.backend.domain.firstcome.quiz.dto.QuizFirstComeSubmitResponseDto;
 import com.hyundai.softeer.backend.domain.firstcome.quiz.entity.QuizFirstCome;
+import com.hyundai.softeer.backend.domain.firstcome.quiz.repository.QuizFirstComeRepository;
 import com.hyundai.softeer.backend.domain.prize.entity.Prize;
 import com.hyundai.softeer.backend.domain.subevent.entity.SubEvent;
 import com.hyundai.softeer.backend.domain.subevent.repository.SubEventRepository;
@@ -20,6 +21,7 @@ public class QuizWinnerDrawSync implements QuizWinnerDraw {
 
     private final WinnerRepository winnerRepository;
     private final WinnerUtil winnerUtil;
+    private final QuizFirstComeRepository quizFirstComeRepository;
 
     @Override
     @Synchronized
@@ -41,6 +43,8 @@ public class QuizWinnerDrawSync implements QuizWinnerDraw {
         }
 
         quizFirstCome.setWinnerCount(winnerCount + 1);
+        quizFirstComeRepository.flush();
+
 
         Prize prize = quizFirstCome.getPrize();
 

--- a/src/main/java/com/hyundai/softeer/backend/domain/winner/repository/WinnerRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/winner/repository/WinnerRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface WinnerRepository extends JpaRepository<Winner, Long> {
     Optional<List<Winner>> findBySubEventId(Long subEventId);
 
-    Optional<Winner> findByUserIdAndSubEventId(Long userId, Long subEventId);
+    List <Winner> findByUserIdAndSubEventId(Long userId, Long subEventId);
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/winner/repository/WinnerRepository.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/winner/repository/WinnerRepository.java
@@ -2,6 +2,8 @@ package com.hyundai.softeer.backend.domain.winner.repository;
 
 import com.hyundai.softeer.backend.domain.winner.entity.Winner;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,7 @@ public interface WinnerRepository extends JpaRepository<Winner, Long> {
     Optional<List<Winner>> findBySubEventId(Long subEventId);
 
     List <Winner> findByUserIdAndSubEventId(Long userId, Long subEventId);
+
+    @Query("SELECT COUNT(w) FROM Winner w WHERE w.subEvent.id = :subEventId")
+    long countWinnerBySubEventId(@Param("subEventId") Long subEventId);
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/winner/utils/WinnerUtil.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/winner/utils/WinnerUtil.java
@@ -1,0 +1,20 @@
+package com.hyundai.softeer.backend.domain.winner.utils;
+
+import com.hyundai.softeer.backend.domain.winner.entity.Winner;
+import com.hyundai.softeer.backend.domain.winner.repository.WinnerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WinnerUtil {
+
+    private final WinnerRepository winnerRepository;
+
+    public List<Winner> isParticipanted(long userId, long subEventId) {
+        List<Winner> byUserIdAndSubEventId = winnerRepository.findByUserIdAndSubEventId(userId, subEventId);
+        return byUserIdAndSubEventId;
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/global/config/QuizFirstComeConfig.java
+++ b/src/main/java/com/hyundai/softeer/backend/global/config/QuizFirstComeConfig.java
@@ -1,0 +1,21 @@
+package com.hyundai.softeer.backend.global.config;
+
+import com.hyundai.softeer.backend.domain.firstcome.quiz.service.QuizWinnerDraw;
+import com.hyundai.softeer.backend.domain.firstcome.quiz.service.QuizWinnerDrawSync;
+import com.hyundai.softeer.backend.domain.subevent.repository.SubEventRepository;
+import com.hyundai.softeer.backend.domain.winner.repository.WinnerRepository;
+import com.hyundai.softeer.backend.domain.winner.utils.WinnerUtil;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuizFirstComeConfig {
+
+    @Bean
+    public QuizWinnerDraw quizWinnerDraw(
+            WinnerRepository winnerRepository,
+            WinnerUtil winnerUtil
+            ) {
+       return new QuizWinnerDrawSync(winnerRepository, winnerUtil);
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/global/config/QuizFirstComeConfig.java
+++ b/src/main/java/com/hyundai/softeer/backend/global/config/QuizFirstComeConfig.java
@@ -1,5 +1,6 @@
 package com.hyundai.softeer.backend.global.config;
 
+import com.hyundai.softeer.backend.domain.firstcome.quiz.repository.QuizFirstComeRepository;
 import com.hyundai.softeer.backend.domain.firstcome.quiz.service.QuizWinnerDraw;
 import com.hyundai.softeer.backend.domain.firstcome.quiz.service.QuizWinnerDrawSync;
 import com.hyundai.softeer.backend.domain.subevent.repository.SubEventRepository;
@@ -14,8 +15,9 @@ public class QuizFirstComeConfig {
     @Bean
     public QuizWinnerDraw quizWinnerDraw(
             WinnerRepository winnerRepository,
-            WinnerUtil winnerUtil
+            WinnerUtil winnerUtil,
+            QuizFirstComeRepository quizFirstComeRepository
             ) {
-       return new QuizWinnerDrawSync(winnerRepository, winnerUtil);
+       return new QuizWinnerDrawSync(winnerRepository, winnerUtil, quizFirstComeRepository);
     }
 }

--- a/src/test/java/com/hyundai/softeer/backend/domain/winner/repository/WinnerRepositoryTest.java
+++ b/src/test/java/com/hyundai/softeer/backend/domain/winner/repository/WinnerRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.hyundai.softeer.backend.domain.winner.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.junit.jupiter.api.Assertions.*;
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE, connection = EmbeddedDatabaseConnection.H2)
+@Sql(scripts = "classpath:sql/integration-h2.sql")
+class WinnerRepositoryTest {
+
+    @Autowired
+    private WinnerRepository winnerRepository;
+
+    @Test
+    @DisplayName("서브이벤트 당첨자 수 조회 쿼리")
+    void countWinnerBySubEventIdTest() {
+        // given
+        Long subEventId = 1L;
+
+        // when
+        Long winners = winnerRepository.countWinnerBySubEventId(subEventId);
+
+        // then
+        Assertions.assertThat(winners).isEqualTo(1L);
+    }
+
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #159 

### 💡 작업동기
- 선착순 로직 확장 필요성
- race condition 발생

### 🔑 주요 변경사항
- 선착순 로직에 `@Synchronized` 작성
- QuizWinnerDraw interface로 추상화

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- 동기화 이슈 확인 필요