### PR TITLE
중복 퀴즈 제출 제한합니다.

### DIFF
--- a/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizFirstComeService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/firstcome/quiz/service/QuizFirstComeService.java
@@ -237,6 +237,10 @@ public class QuizFirstComeService {
             return QuizFirstComeSubmitResponseDto.notCorrect();
         }
 
+        if(eventUserRepository.findByUserIdAndSubEventId(authenticatedUser.getId(), subEventId).isPresent()) {
+            return QuizFirstComeSubmitResponseDto.alreadyParticipant();
+        }
+
         EventUser newEventUser = EventUser.builder()
                 .user(authenticatedUser)
                 .subEvent(subEvent)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #203 

### 💡 작업동기
- 퀴즈 정답 제출 후 중복 제출 가능한 문제가 발생
- 서버 입장에서 더 이상 받을 필요 없는 api 증가

### 🔑 주요 변경사항
- 이벤트 유저가 이미 있는지 확인하여 있다면 참가한 유저로 판단하는 로직 작성

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- 관련 이슈를 입력해주세요.
