### PR TITLE
결과 미리보기를 위한 이미지 저장 및 동적 템플릿 생성합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,12 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // template engine
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    // aws
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     // db
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/eventuser/entity/EventUser.java
@@ -67,6 +67,8 @@ public class EventUser {
     @Builder.Default
     private Integer shareBonusChance = -1;
 
+    private String resultImgUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/DrawingLotteryController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/DrawingLotteryController.java
@@ -19,9 +19,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -157,5 +159,15 @@ public class DrawingLotteryController {
             @Validated SubEventRequest subEventRequest
     ) {
         return new BaseResponse<>(drawingLotteryService.getDrawingTotalScore(authenticatedUser, subEventRequest));
+    }
+
+    @PostMapping("/image")
+    @ResponseStatus(HttpStatus.CREATED)
+    public BaseResponse<Void> saveDrawImage(
+            @RequestParam("image") MultipartFile file,
+            @Parameter(hidden = true) @CurrentUser User authenticatedUser
+    ) {
+        drawingLotteryService.saveDrawImage(file, eventId, authenticatedUser);
+        return new BaseResponse<>(201, "정상적으로 저장되었습니다.", null);
     }
 }

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/DrawingLotteryController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/DrawingLotteryController.java
@@ -161,6 +161,20 @@ public class DrawingLotteryController {
         return new BaseResponse<>(drawingLotteryService.getDrawingTotalScore(authenticatedUser, subEventRequest));
     }
 
+    @Tag(name = "Drawing Lottery")
+    @Operation(summary = "드로잉 결과 이미지 저장", description = """
+            # 드로잉 결과 이미지 저장 api
+            
+            - 드로잉 결과 이미지를 aws s3에 저장합니다.
+             
+            ## 응답
+                        
+            - 이미지 저장 성공 시 `201`를 반환합니다..
+             
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "이미지 저장 성공 시", useReturnTypeSchema = true),
+    })
     @PostMapping("/image")
     @ResponseStatus(HttpStatus.CREATED)
     public BaseResponse<Void> saveDrawImage(

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/PreviewController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/PreviewController.java
@@ -3,6 +3,10 @@ package com.hyundai.softeer.backend.domain.lottery.drawing.controller;
 import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
 import com.hyundai.softeer.backend.domain.lottery.drawing.dto.PreviewRequest;
 import com.hyundai.softeer.backend.domain.lottery.drawing.service.PreviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -17,6 +21,21 @@ public class PreviewController {
 
     private final PreviewService previewService;
 
+    @Tag(name = "Drawing Lottery")
+    @Operation(summary = "미리 보기용 html 반환", description = """
+            # open graph html 반환
+            
+            - 이미지 url과 점수, 이름이 담긴 open graph html이 반환됩니다.
+             
+            ## 응답
+                        
+            - 렌더링 성공 시 `200`이 반환됩니다.
+             
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "html 렌더링 성공 시", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "400", description = "이벤트를 참여하지 않은 sharedUrl이 들어올 경우", useReturnTypeSchema = true)
+    })
     @GetMapping("/preview")
     public String preview(
             @Validated PreviewRequest previewRequest,

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/PreviewController.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/controller/PreviewController.java
@@ -1,0 +1,33 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.controller;
+
+import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
+import com.hyundai.softeer.backend.domain.lottery.drawing.dto.PreviewRequest;
+import com.hyundai.softeer.backend.domain.lottery.drawing.service.PreviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v1/lottery/drawing")
+@RequiredArgsConstructor
+public class PreviewController {
+
+    private final PreviewService previewService;
+
+    @GetMapping("/preview")
+    public String preview(
+            @Validated PreviewRequest previewRequest,
+            Model model
+    ) {
+        EventUser eventUser = previewService.preview(previewRequest);
+
+        model.addAttribute("resultImgUrl", eventUser.getResultImgUrl());
+        model.addAttribute("name", eventUser.getUser().getName());
+        model.addAttribute("score", eventUser.getGameScore());
+
+        return "preview";
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/dto/PreviewRequest.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/dto/PreviewRequest.java
@@ -1,0 +1,12 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class PreviewRequest {
+    @NotBlank
+    @Size(min = 6, max = 6, message = "사용자 ID는 정확히 6글자여야 합니다.")
+    String sharedUrl;
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/exception/DrawingEventNotParticipantException.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/exception/DrawingEventNotParticipantException.java
@@ -1,0 +1,10 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.exception;
+
+import com.hyundai.softeer.backend.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class DrawingEventNotParticipantException extends BaseException {
+    public DrawingEventNotParticipantException() {
+        super(HttpStatus.BAD_REQUEST, "아직 드로잉 이벤트를 참여하지 않은 유저 입니다.");
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/service/PreviewService.java
+++ b/src/main/java/com/hyundai/softeer/backend/domain/lottery/drawing/service/PreviewService.java
@@ -1,0 +1,29 @@
+package com.hyundai.softeer.backend.domain.lottery.drawing.service;
+
+import com.hyundai.softeer.backend.domain.eventuser.entity.EventUser;
+import com.hyundai.softeer.backend.domain.eventuser.exception.EventUserNotFoundException;
+import com.hyundai.softeer.backend.domain.eventuser.repository.EventUserRepository;
+import com.hyundai.softeer.backend.domain.lottery.drawing.dto.PreviewRequest;
+import com.hyundai.softeer.backend.domain.lottery.drawing.exception.DrawingEventNotParticipantException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PreviewService {
+
+    private final EventUserRepository eventUserRepository;
+
+    public EventUser preview(PreviewRequest previewRequest) {
+        String sharedUrl = previewRequest.getSharedUrl();
+
+        EventUser eventUser = eventUserRepository.findBySharedUrl(sharedUrl)
+                .orElseThrow(() -> new EventUserNotFoundException());
+
+        if(eventUser.getResultImgUrl().isEmpty()) {
+            throw new DrawingEventNotParticipantException();
+        }
+
+        return eventUser;
+    }
+}

--- a/src/main/java/com/hyundai/softeer/backend/global/config/S3Config.java
+++ b/src/main/java/com/hyundai/softeer/backend/global/config/S3Config.java
@@ -1,0 +1,19 @@
+package com.hyundai.softeer.backend.global.config;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(Regions.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>웹페이지 제목</title>
+
+    <!-- Open Graph 메타 태그 -->
+    <meta property="og:title" content="드로잉 이벤트~!!">
+    <meta property="og:description" th:content="${name} + '님은 ' + ${score} + '를 얻으셨어요~~ 한번 도전 해보실래요?'">
+    <meta property="og:image" th:content="${resultImgUrl}">
+    <meta property="og:url">
+    <meta property="og:type" content="website">
+
+    <!-- 추가적인 Open Graph 태그 -->
+    <meta property="og:locale" content="ko_KR">
+</head>
+<body>
+<h1>웹페이지 내용</h1>
+<p>이곳에 실제 웹페이지 내용을 작성합니다.</p>
+</body>
+</html>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #207 

### 💡 작업동기
- 사용자 ux를 생각하여 친구의 결과를 미리 보게하는 것이 좋아보임

### 🔑 주요 변경사항
- s3 이미지 저장 로직 작성
- 그림 저장 api 및 미리보기 html (open graph) 반환

### 🏞 스크린샷
<img width="696" alt="image" src="https://github.com/user-attachments/assets/476ea002-ca0c-43e7-88ff-7d378f2eaa5a">

### 관련 이슈
- 관련 이슈를 입력해주세요.
